### PR TITLE
Fix plural export

### DIFF
--- a/lib/cldr/download.rb
+++ b/lib/cldr/download.rb
@@ -6,7 +6,7 @@ require 'tempfile'
 module Cldr
   class << self
     def download(source = nil, target = nil)
-      source ||= 'http://unicode.org/Public/cldr/1.7.2/core.zip'
+      source ||= 'http://unicode.org/Public/cldr/21/core.zip'
       target ||= File.expand_path('./vendor/cldr')
 
       source = URI.parse(source)

--- a/lib/cldr/export.rb
+++ b/lib/cldr/export.rb
@@ -43,7 +43,11 @@ module Cldr
         else
           data = locales(locale, options).inject({}) do |result, locale|
             data = Data.const_get(component.to_s.camelize).new(locale)
-            data ? data.deep_merge(result) : result
+            if data
+              data.is_a?(Hash) ? data.deep_merge(result) : data
+            else
+              result
+            end
           end
           # data = resolve_links if options[:merge] TODO!!
           data


### PR DESCRIPTION
Every class under `Cldr::Export::Data` inherits from `Cldr::Export::Data::Base` (which inherits from `Hash`) except `Cldr::Export::Data::Plurals`.  Instead, `Cldr::Export::Data::Plurals` inherits directly from `String`.  This means that `#deep_merge` is not available for the plural exporter as it is for all the others.  This pull request fixes this issue by returning `data` directly when `data` is not a `Hash`.

The error looks like this: "undefined method 'deep_merge' for #<Cldr::Data::Plurals ...>"
