### PR TITLE
Remove .rvmrc and add it to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 /data/
+.rvmrc

--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,0 @@
-rvm 1.9.2@ruby-cldr


### PR DESCRIPTION
Having `.rvmrc` in a repository like this one is not very friendly to other developers because it freezes Ruby version forces other people to create and use a gemset with exactly the same name as the one in the project's `.rvmrc` file. It's better to add `.rvmrc` to your global `.gitinore`, but I think it wouldn't hurt to have it in the project's `.gitignore` as well.
