### PR TITLE
Update day-period parsing.

### DIFF
--- a/lib/cldr/export/data/calendars/gregorian.rb
+++ b/lib/cldr/export/data/calendars/gregorian.rb
@@ -10,7 +10,7 @@ module Cldr
               :days     => contexts('day'),
               :eras     => contexts('era'),
               :quarters => contexts('quarter'),
-              :periods  => periods,
+              :periods  => contexts('dayPeriod'),
               :fields   => fields,
               :formats => {
                 :date     => formats('date'),
@@ -62,16 +62,6 @@ module Cldr
           end
         
           def xpath_width
-          end
-
-          def periods
-            am = select(calendar, "am").first
-            pm = select(calendar, "pm").first
-
-            result = {}
-            result[:am] = am.content if am
-            result[:pm] = pm.content if pm
-            result
           end
 
           def eras


### PR DESCRIPTION
As described [here](http://cldr.unicode.org/development/development-process/design-proposals/day-period-design) day periods format was changed in the latest version of CLDR. For example, [here](http://unicode.org/cldr/trac/browser/trunk/common/main/de.xml#L1288) are day periods for de locale. 

PR #3 changed the default version of CLDR to v21 so updating of day periods exporting seems appropriate to me. Though, it'll break on the older versions of CLDR data.

I assume I should update tests as well, but I didn't figure out how to run full test suit in this project. Can someone help me with that?
