### PR TITLE
Adding list support

### DIFF
--- a/lib/cldr/export/data.rb
+++ b/lib/cldr/export/data.rb
@@ -13,6 +13,7 @@ module Cldr
       autoload :Territories,   'cldr/export/data/territories'
       autoload :Timezones,     'cldr/export/data/timezones'
       autoload :Units,         'cldr/export/data/units'
+      autoload :Lists,         'cldr/export/data/lists'
 
       class << self
         def dir

--- a/lib/cldr/export/data/lists.rb
+++ b/lib/cldr/export/data/lists.rb
@@ -1,0 +1,19 @@
+module Cldr
+  module Export
+    module Data
+      class Lists < Base
+        def initialize(locale)
+          super
+          update(:lists => lists)
+        end
+
+        def lists
+          select('listPatterns/listPattern/listPatternPart').inject({}) do |result, node|
+            result[node.attribute('type').value.to_sym] = node.content
+            result
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the ability to export data for list formatting.  Here's how the resulting YAML file looks for English:

```
en: 
  lists: 
    2: "{0} and {1}"
    end: "{0}, and {1}"
    middle: "{0}, {1}"
    start: "{0}, {1}"
```

Reference material: http://cldr.unicode.org/development/development-process/design-proposals/list-formatting
