### PR TITLE
Outputting additional date formats

### DIFF
--- a/lib/cldr/export/data/calendars/gregorian.rb
+++ b/lib/cldr/export/data/calendars/gregorian.rb
@@ -16,7 +16,8 @@ module Cldr
                 :date     => formats('date'),
                 :time     => formats('time'),
                 :datetime => formats('dateTime')
-              }
+              },
+              :additional_formats => additional_formats
             )
           end
 
@@ -110,7 +111,15 @@ module Cldr
             end
             formats
           end
-        
+
+          def additional_formats
+            select(calendar, "dateTimeFormats/availableFormats/dateFormatItem").inject({}) do |result, node|
+              key = node.attribute('id').value
+              result[key] = node.content
+              result
+            end
+          end
+
           def default_format(type)
             if node = select(calendar, "#{type}Formats/default").first
               key = node.attribute('choice').value.to_sym


### PR DESCRIPTION
CLDR defines a number of date/time formats that aren't on the general list of formats (short, medium, long, etc).  They're intended for use when the basic formats won't suffice, and are available in the same general location as the rest of the date formatting stuff in the source XML.  This PR adds these formats to the output for `calendars.yml`, eg:

```
:additional_formats:
  :EHm: E HH:mm
  :EHms: E HH:mm:ss
  :Ed: d E
  :Ehm: E h:mm a
  :Ehms: E h:mm:ss a
  :Gy: y G
  :H: HH
  :Hm: HH:mm
  :Hms: HH:mm:ss
  :M: L
... etc
```
