### PR TITLE
Put quotes around plural symbols so that locales like en-GB work as expected

### DIFF
--- a/lib/cldr/export.rb
+++ b/lib/cldr/export.rb
@@ -69,7 +69,7 @@ module Cldr
 
       def plural_data(component, locale, options = {})
         data = default_data(component, locale, options)
-        "{ :#{locale} => { :i18n => { :plural => { :keys => #{data[:keys].inspect}, :rule => #{data[:rule]} } } } }"
+        "{ :'#{locale}' => { :i18n => { :plural => { :keys => #{data[:keys].inspect}, :rule => #{data[:rule]} } } } }"
       end
 
       def currency_rounding_data(component, locale, options = {})


### PR DESCRIPTION
I poorly assumed symbol keys in exported plurals files wouldn't contain non-symbol characters like dash ("-"), which is messing up "en-GB" in twitter-cldr-rb :(  This PR fixes the issue.
