### PR TITLE
Update CLDR to version 24 and implement new syntax for plural rules

### DIFF
--- a/lib/cldr/download.rb
+++ b/lib/cldr/download.rb
@@ -5,7 +5,7 @@ require 'zip'
 module Cldr
     class << self
         def download(source = nil, target = nil)
-            source ||= 'http://unicode.org/Public/cldr/23/core.zip'
+            source ||= 'http://unicode.org/Public/cldr/24/core.zip'
             target ||= File.expand_path('./vendor/cldr')
 
             URI.parse(source).open do |tempfile|

--- a/lib/cldr/export/data/units.rb
+++ b/lib/cldr/export/data/units.rb
@@ -4,11 +4,23 @@ module Cldr
       class Units < Base
         def initialize(locale)
           super
-          update(:units => units)
+          update(
+            :units => {
+              :unitLength => unitLength,
+              :durationUnit => durationUnit,
+            }
+          )
         end
 
-        def units
-          select('units/unit').inject({}) do |result, node|
+        def unitLength
+          select('units/unitLength').inject({}) do |result, node|
+            result[node.attribute('type').value.to_sym] = units(node)
+            result
+          end
+        end
+
+        def units(node)
+          node.xpath('unit').inject({}) do |result, node|
             result[node.attribute('type').value.to_sym] = unit(node)
             result
           end
@@ -16,10 +28,15 @@ module Cldr
 
         def unit(node)
           node.xpath('unitPattern').inject({}) do |result, node|
-            alt = node.attribute('alt') ? node.attribute('alt').value.to_sym : :default
             count = node.attribute('count') ? node.attribute('count').value.to_sym : :one
-            result[alt] ||= {}
-            result[alt][count] = node.content unless draft?(node)
+            result[count] = node.content unless draft?(node)
+            result
+          end
+        end
+
+        def durationUnit
+          select('units/durationUnit').inject({}) do |result, node|
+            result[node.attribute('type').value.to_sym] = node.xpath('durationUnitPattern').first.content
             result
           end
         end

--- a/lib/cldr/thor.rb
+++ b/lib/cldr/thor.rb
@@ -5,7 +5,7 @@ module Cldr
   class Thor < ::Thor
     namespace 'cldr'
 
-    desc "download [--source=http://unicode.org/Public/cldr/2.0.1/core.zip] [--target=./vendor]",
+    desc "download [--source=http://unicode.org/Public/cldr/24/core.zip] [--target=./vendor]",
          "Download and extract CLDR data from source to target dir"
     method_options %w(source -s) => :string,
                    %w(target -t) => :string

--- a/test/export/data/plurals_test.rb
+++ b/test/export/data/plurals_test.rb
@@ -21,121 +21,158 @@ class TestCldrDataPluralParser < Test::Unit::TestCase
   end
   
   def test_lookup_rule_by_locale
-    assert_equal "lambda { |n| n == 1 ? :one : :other }", cldr_rules.rule(:de).to_ruby
+    assert_equal 'lambda { |n| (n.to_i.to_s.length == 1 && ((v = n.to_s.split(".")).count > 1 ? v.last.length : 0) == 0) ? :one : :other }', cldr_rules.rule(:de).to_ruby
   end
 
-  def test_parses_n
-    assert Cldr::Export::Data::Plurals::Rule.parse('n').is_a?(Cldr::Export::Data::Plurals::Expression)
+  def test_parses_empty
+    assert Cldr::Export::Data::Plurals::Rule.parse('').is_a?(Cldr::Export::Data::Plurals::Expression)
+    assert Cldr::Export::Data::Plurals::Rule.parse(' ').is_a?(Cldr::Export::Data::Plurals::Expression)
+    assert Cldr::Export::Data::Plurals::Rule.parse(' @integer').is_a?(Cldr::Export::Data::Plurals::Expression)
+    assert Cldr::Export::Data::Plurals::Rule.parse('@decimal').is_a?(Cldr::Export::Data::Plurals::Expression)
   end
 
   def test_parses_n_is_1
     rule = Cldr::Export::Data::Plurals::Rule.parse('n is 1')
-    assert_equal [:is, '1'], [rule.operator, rule.operand]
+    assert_equal [:is, 1], [rule.operator, rule.operand]
   end
 
   def test_parses_n_mod_1_is_1
     rule = Cldr::Export::Data::Plurals::Rule.parse('n mod 1 is 1')
-    assert_equal [:is, '1', '1'], [rule.operator, rule.operand, rule.mod]
+    assert_equal [:is, 1, '1', 'n'], [rule.operator, rule.operand, rule.mod, rule.type]
   end
 
   def test_parses_n_is_not_1
     rule = Cldr::Export::Data::Plurals::Rule.parse('n is not 1')
-    assert_equal [:is, '1', true], [rule.operator, rule.operand, rule.negate]
+    assert_equal [:is, 1, true, 'n'], [rule.operator, rule.operand, rule.negate, rule.type]
   end
 
   def test_parses_n_mod_1_is_not_1
     rule = Cldr::Export::Data::Plurals::Rule.parse('n mod 1 is not 1')
-    assert_equal [:is, '1', true, '1'], [rule.operator, rule.operand, rule.negate, rule.mod]
+    assert_equal [:is, 1, true, '1', 'n'], [rule.operator, rule.operand, rule.negate, rule.mod, rule.type]
   end
 
   def test_parses_n_in_1_2
     rule = Cldr::Export::Data::Plurals::Rule.parse('n in 1..2')
-    assert_equal [:in, '[1, 2]'], [rule.operator, rule.operand]
+    assert_equal [:in, [[],[1..2]], 'n'], [rule.operator, rule.operand, rule.type]
   end
 
   def test_parses_n_mod_1_in_1_2
     rule = Cldr::Export::Data::Plurals::Rule.parse('n mod 1 in 1..2')
-    assert_equal [:in, '[1, 2]', '1'], [rule.operator, rule.operand, rule.mod]
+    assert_equal [:in, [[],[1..2]], '1', 'n'], [rule.operator, rule.operand, rule.mod, rule.type]
   end
 
   def test_parses_n_not_in_1_2
     rule = Cldr::Export::Data::Plurals::Rule.parse('n not in 1..2')
-    assert_equal [:in, '[1, 2]', true], [rule.operator, rule.operand, rule.negate]
+    assert_equal [:in, [[],[1..2]], true, 'n'], [rule.operator, rule.operand, rule.negate, rule.type]
   end
 
   def test_parses_n_mod_1_not_in_1_2
     rule = Cldr::Export::Data::Plurals::Rule.parse('n mod 1 not in 1..2')
-    assert_equal [:in, '[1, 2]', true, '1'], [rule.operator, rule.operand, rule.negate, rule.mod]
+    assert_equal [:in, [[],[1..2]], true, '1', 'n'], [rule.operator, rule.operand, rule.negate, rule.mod, rule.type]
   end
 
   def test_parses_n_within_0_2
     expression = Cldr::Export::Data::Plurals::Rule.parse('n within 0..2')
-    assert_equal [:within, %w{0 2}], [expression.operator, expression.operand]
+    assert_equal [:within, 0..2, 'n'], [expression.operator, expression.operand, expression.type]
+  end
+
+  def test_parses_n_list_range
+    expression = Cldr::Export::Data::Plurals::Rule.parse('n % 100 != 10..19,30,34,39,90..99')
+    assert_equal [:in, [[30, 34, 39],[10..19, 90..99]], true, '100', 'n'], [expression.operator, expression.operand, expression.negate, expression.mod, expression.type]
   end
 
   def test_parses_or_condition
     rule = Cldr::Export::Data::Plurals::Rule.parse('n mod 1 is not 2 or n mod 2 in 3..4')
     assert_equal 2, rule.size
-    assert_equal [:is, '2', true, '1'], [rule[0].operator, rule[0].operand, rule[0].negate, rule[0].mod]
-    assert_equal [:in, '[3, 4]', false, '2'], [rule[1].operator, rule[1].operand, rule[1].negate, rule[1].mod]
+    assert_equal [:is, 2, true, '1', 'n'], [rule[0].operator, rule[0].operand, rule[0].negate, rule[0].mod, rule[0].type]
+    assert_equal [:in, [[],[3..4]], false, '2', 'n'], [rule[1].operator, rule[1].operand, rule[1].negate, rule[1].mod, rule[1].type]
   end
 
   def test_parses_and_condition
     rule = Cldr::Export::Data::Plurals::Rule.parse('n mod 1 is not 2 and n mod 2 in 3..4')
     assert_equal 2, rule.size
-    assert_equal [:is, '2', true, '1'], [rule[0].operator, rule[0].operand, rule[0].negate, rule[0].mod]
-    assert_equal [:in, '[3, 4]', false, '2'], [rule[1].operator, rule[1].operand, rule[1].negate, rule[1].mod]
+    assert_equal [:is, 2, true, '1', 'n'], [rule[0].operator, rule[0].operand, rule[0].negate, rule[0].mod, rule[0].type]
+    assert_equal [:in, [[],[3..4]], false, '2', 'n'], [rule[1].operator, rule[1].operand, rule[1].negate, rule[1].mod, rule[1].type]
   end
 
-  def test_compiles_n
-    assert_equal 'n', Cldr::Export::Data::Plurals::Rule.parse('n').to_ruby
+  def test_parses_and_priority
+    rule = Cldr::Export::Data::Plurals::Rule.parse('i = 0 or v != 1 and f % 2 = 3..4')
+    assert_equal 2, rule.size
+    assert_equal 2, rule[1].size
+    assert_equal [:is, 0, 'i'], [rule[0].operator, rule[0].operand, rule[0].type]
+    assert_equal [:is, 1, true, 'v'], [rule[1][0].operator, rule[1][0].operand, rule[1][0].negate, rule[1][0].type]
+    assert_equal [:in, [[],[3..4]], '2', 'f'], [rule[1][1].operator, rule[1][1].operand, rule[1][1].mod, rule[1][1].type]
+  end
+
+  def test_compiles_empty
+    assert_equal nil, Cldr::Export::Data::Plurals::Rule.parse('').to_ruby
+    assert_equal nil, Cldr::Export::Data::Plurals::Rule.parse(' ').to_ruby
+    assert_equal nil, Cldr::Export::Data::Plurals::Rule.parse(' @integer').to_ruby
+    assert_equal nil, Cldr::Export::Data::Plurals::Rule.parse('@decimal').to_ruby
   end
 
   def test_compiles_n_is_2
-    assert_equal 'n == 2', Cldr::Export::Data::Plurals::Rule.parse('n is 2').to_ruby
+    assert_equal 'n.to_f == 2', Cldr::Export::Data::Plurals::Rule.parse('n is 2').to_ruby
   end
 
   def test_compiles_n_mod_1_is_2
-    assert_equal 'n % 1 == 2', Cldr::Export::Data::Plurals::Rule.parse('n mod 1 is 2').to_ruby
+    assert_equal 'n.to_f % 1 == 2', Cldr::Export::Data::Plurals::Rule.parse('n mod 1 is 2').to_ruby
   end
 
   def test_compiles_n_is_not_2
-    assert_equal 'n != 2', Cldr::Export::Data::Plurals::Rule.parse('n is not 2').to_ruby
+    assert_equal 'n.to_f != 2', Cldr::Export::Data::Plurals::Rule.parse('n is not 2').to_ruby
   end
 
   def test_compiles_n_mod_1_is_not_2
-    assert_equal 'n % 1 != 2', Cldr::Export::Data::Plurals::Rule.parse('n mod 1 is not 2').to_ruby
+    assert_equal 'n.to_f % 1 != 2', Cldr::Export::Data::Plurals::Rule.parse('n mod 1 is not 2').to_ruby
   end
 
   def test_compiles_n_in_1_2
-    assert_equal '[1, 2].include?(n)', Cldr::Export::Data::Plurals::Rule.parse('n in 1..2').to_ruby
+    assert_equal '((n.to_f % 1).zero? && (1..2).include?(n.to_f))', Cldr::Export::Data::Plurals::Rule.parse('n in 1..2').to_ruby
   end
 
   def test_compiles_n_mod_1_in_1_2
-    assert_equal '[1, 2].include?(n % 1)', Cldr::Export::Data::Plurals::Rule.parse('n mod 1 in 1..2').to_ruby
+    assert_equal '(((n.to_f % 1) % 1).zero? && (1..2).include?(n.to_f % 1))', Cldr::Export::Data::Plurals::Rule.parse('n mod 1 in 1..2').to_ruby
   end
 
   def test_compiles_n_not_in_1_2
-    assert_equal '![1, 2].include?(n)', Cldr::Export::Data::Plurals::Rule.parse('n not in 1..2').to_ruby
+    assert_equal '((n.to_f % 1).zero? && !(1..2).include?(n.to_f))', Cldr::Export::Data::Plurals::Rule.parse('n not in 1..2').to_ruby
   end
 
   def test_compiles_n_mod_1_not_in_1_2
-    assert_equal '![1, 2].include?(n % 1)', Cldr::Export::Data::Plurals::Rule.parse('n mod 1 not in 1..2').to_ruby
+    assert_equal '(((n.to_f % 1) % 1).zero? && !(1..2).include?(n.to_f % 1))', Cldr::Export::Data::Plurals::Rule.parse('n mod 1 not in 1..2').to_ruby
   end
 
   def test_compiles_or_condition
-    assert_equal 'n % 1 != 2 || [3, 4].include?(n % 2)', Cldr::Export::Data::Plurals::Rule.parse('n mod 1 is not 2 or n mod 2 in 3..4').to_ruby
+    assert_equal '(n.to_f % 1 != 2 || (((n.to_f % 2) % 1).zero? && (3..4).include?(n.to_f % 2)))', Cldr::Export::Data::Plurals::Rule.parse('n mod 1 is not 2 or n mod 2 in 3..4').to_ruby
   end
 
   def test_compiles_and_condition
-    assert_equal 'n % 1 != 2 && [3, 4].include?(n % 2)', Cldr::Export::Data::Plurals::Rule.parse('n mod 1 is not 2 and n mod 2 in 3..4').to_ruby
+    assert_equal '(n.to_f % 1 != 2 && (((n.to_f % 2) % 1).zero? && (3..4).include?(n.to_f % 2)))', Cldr::Export::Data::Plurals::Rule.parse('n mod 1 is not 2 and n mod 2 in 3..4').to_ruby
+  end
+
+  def test_compiles_and_priority
+    assert_equal '(n.to_i.to_s.length == 0 || (((v = n.to_s.split(".")).count > 1 ? v.last.length : 0) != 1 && (((((f = n.to_s.split(".")).count > 1 ? f.last.to_i : 0) % 2) % 1).zero? && (3..4).include?(((f = n.to_s.split(".")).count > 1 ? f.last.to_i : 0) % 2))))', Cldr::Export::Data::Plurals::Rule.parse('i = 0 or v != 1 and f mod 2 = 3..4').to_ruby
   end
 
   def test_compiles_n_mod_100_in_3_99
-    assert_equal '[3, 4, 5, 6].include?(n % 100)', Cldr::Export::Data::Plurals::Rule.parse('n mod 100 in 3..6').to_ruby
+    assert_equal '(((n.to_f % 100) % 1).zero? && (3..6).include?(n.to_f % 100))', Cldr::Export::Data::Plurals::Rule.parse('n mod 100 in 3..6').to_ruby
   end
 
   def test_compiles_n_within_0_2
-    assert_equal 'n.between?(0, 2)', Cldr::Export::Data::Plurals::Rule.parse('n within 0..2').to_ruby
+    assert_equal 'n.to_f.between?(0, 2)', Cldr::Export::Data::Plurals::Rule.parse('n within 0..2').to_ruby
+  end
+
+  def test_compiles_n_list_range
+    assert_equal '(![30, 34, 39].include?(n.to_f % 100) || (((n.to_f % 100) % 1).zero? && (!(10..19).include?(n.to_f % 100) || !(90..99).include?(n.to_f % 100))))', Cldr::Export::Data::Plurals::Rule.parse('n % 100 != 10..19,30,34,39,90..99').to_ruby
+  end
+
+  def test_compiles_n_list_range2
+    assert_equal '((n.to_f % 100) != 100 || (((n.to_f % 100) % 1).zero? && (!(10..19).include?(n.to_f % 100) || !(90..99).include?(n.to_f % 100))))', Cldr::Export::Data::Plurals::Rule.parse('n % 100 != 10..19,90..99,100').to_ruby
+  end
+
+  def test_eval_n_in
+    n = 3.3
+    assert_equal false, eval(Cldr::Export::Data::Plurals::Rule.parse('n mod 100 in 3..6').to_ruby, binding)
   end
 end

--- a/test/export/data/units_test.rb
+++ b/test/export/data/units_test.rb
@@ -5,25 +5,24 @@ require File.expand_path(File.join(File.dirname(__FILE__) + '/../../test_helper'
 class TestCldrDataUnits < Test::Unit::TestCase
   test 'units' do
     units = {
-      :day    => { :one => "{0} Tag",   :other => "{0} Tage" },
-      :week   => { :one => "{0} Woche", :other => "{0} Wochen" },
-      :month  => { :one => "{0} Monat", :other => "{0} Monate" },
-      :year   => { :one => "{0} Jahr",  :other => "{0} Jahre" },
-      :hour   => { :one => "{0} Std.",  :other => "{0} Std." },
-      :minute => { :one => "{0} Min.",  :other => "{0} Min." },
-      :second => { :one => "{0} Sek.",  :other => "{0} Sek." }
+      :day    => { :one => "{0} Tag",     :other => "{0} Tage" },
+      :week   => { :one => "{0} Woche",   :other => "{0} Wochen" },
+      :month  => { :one => "{0} Monat",   :other => "{0} Monate" },
+      :year   => { :one => "{0} Jahr",    :other => "{0} Jahre" },
+      :hour   => { :one => "{0} Stunde",  :other => "{0} Stunden" },
+      :minute => { :one => "{0} Minute",  :other => "{0} Minuten" },
+      :second => { :one => "{0} Sekunde", :other => "{0} Sekunden" }
     }
-    keys = %w(day week month year hour minute second).sort
-    data = Cldr::Export::Data::Units.new('de')[:units]
+    data = Cldr::Export::Data::Units.new('de')[:units][:unitLength][:long]
 
-    assert_equal keys, data.keys.map { |key| key.to_s }.sort
-    assert_equal units[:day],    data[:day]
-    assert_equal units[:week],   data[:week]
-    assert_equal units[:month],  data[:month]
-    assert_equal units[:year],   data[:year]
-    assert_equal units[:hour],   data[:hour]
-    assert_equal units[:minute], data[:minute]
-    assert_equal units[:second], data[:second]
+    assert_operator data.keys.count, :>=, 46
+    assert_equal units[:day],    data[:'duration-day']
+    assert_equal units[:week],   data[:'duration-week']
+    assert_equal units[:month],  data[:'duration-month']
+    assert_equal units[:year],   data[:'duration-year']
+    assert_equal units[:hour],   data[:'duration-hour']
+    assert_equal units[:minute], data[:'duration-minute']
+    assert_equal units[:second], data[:'duration-second']
   end
 
   # Cldr::Export::Data.locales.each do |locale|


### PR DESCRIPTION
Updated to CLDR v24 and implemented new syntax for plural rules. Also fixed changes in units exporter. This resolves #19

Now with this PR, plural rules parser is fully based on [LDML Language Plural Rules](http://www.unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules) spec and successfully parses plural data. Before it wasn't fully compliant even for old syntax.

I noticed there's [treetop files for plural rules](/svenfuchs/ruby-cldr/blob/master/lib/cldr/export/data/plurals/cldr_grammar.treetop) but it doesn't seem to be used anywhere and so I didn't updated it.
