### PR TITLE
Fix Plural Data Export

### DIFF
--- a/lib/cldr/export/data/plurals/rules.rb
+++ b/lib/cldr/export/data/plurals/rules.rb
@@ -92,7 +92,7 @@ module Cldr
           end
 
           def to_ruby
-            @condition ||= 'lambda { |n| ' + reverse.inject(':other') do |result, (key, code)|
+            @condition ||= 'lambda { |n| n = n.respond_to?(:abs) ? n.abs : 0;' + reverse.inject(':other') do |result, (key, code)|
               code = self.class.parse(code).to_ruby
               if code
                 "#{code} ? :#{key} : #{result}"
@@ -149,14 +149,13 @@ module Cldr
                 op = '(w = n.to_s.split(".")).size > 1 ? w.last.gsub(/0+$/, "").length : 0'
                 enclose = true
               else
-                op = 'n.to_f.abs'
+                op = 'n.to_f'
               end
               if @mod
                 op = '(' << op << ')' if enclose
                 op << ' % ' << @mod.to_s
                 enclose = false
               end
-              op = "n = n.respond_to?(:abs) ? n.abs : n; #{op}"
               case @operator
               when :is
                 op = '(' << op << ')' if enclose


### PR DESCRIPTION
Looks like plurals were slightly broken since the upgrade to CLDR v24.  The code for English plurals produced the following results:

``` ruby
n = 1
(n.to_i.to_s.length == 1 && ((v = n.to_s.split(".")).count > 1 ? v.last.length : 0) == 0) ? :one : :other
# returns :one
```

So far so good.  But what about when `n = 2`?

``` ruby
n = 2
(n.to_i.to_s.length == 1 && ((v = n.to_s.split(".")).count > 1 ? v.last.length : 0) == 0) ? :one : :other
# returns :one as well
```

The problem stems from the fact that the `i` operand means "integer digits of `n`".  It's currently being treated as the number of integer digits in `n`, which is incorrect.  See [UTS 35](http://www.unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules) for details.
