### PR TITLE
Export subdivisions

### DIFF
--- a/lib/cldr/export/data.rb
+++ b/lib/cldr/export/data.rb
@@ -25,6 +25,7 @@ module Cldr
       autoload :RbnfRoot,                  'cldr/export/data/rbnf_root'
       autoload :RegionCurrencies,          'cldr/export/data/region_currencies'
       autoload :SegmentsRoot,              'cldr/export/data/segments_root'
+      autoload :Subdivisions,              'cldr/export/data/subdivisions'
       autoload :Territories,               'cldr/export/data/territories'
       autoload :TerritoriesContainment,    'cldr/export/data/territories_containment'
       autoload :Timezones,                 'cldr/export/data/timezones'

--- a/lib/cldr/export/data/subdivisions.rb
+++ b/lib/cldr/export/data/subdivisions.rb
@@ -1,0 +1,35 @@
+module Cldr
+  module Export
+    module Data
+      class Subdivisions < Base
+
+        def initialize(locale)
+          super
+          update(:subdivisions => subdivisions)
+        end
+
+        private
+
+        def subdivisions
+          @subdivisions ||= select('localeDisplayNames/subdivisions/subdivision').inject({}) do |result, node|
+            result[node.attribute('type').value.to_sym] = node.content unless draft?(node) or alt?(node)
+            result
+          end
+        end
+
+        def doc
+          begin
+            super
+          rescue Errno::ENOENT
+            @doc = Nokogiri::XML('')
+          end
+        end
+
+        def path
+          @path ||= "#{Cldr::Export::Data.dir}/subdivisions/#{locale.to_s.gsub('-', '_')}.xml"
+        end
+
+      end
+    end
+  end
+end

--- a/test/export/data/subdivisions_test.rb
+++ b/test/export/data/subdivisions_test.rb
@@ -1,0 +1,33 @@
+# encoding: utf-8
+
+require File.expand_path(File.join(File.dirname(__FILE__) + '/../../test_helper'))
+
+class TestCldrDataSubdivisions < Test::Unit::TestCase
+  test 'subdivisions for Canada/Quebec in :ja' do
+    subdivisions = Cldr::Export::Data::Subdivisions.new(:ja)[:subdivisions]
+
+    assert_equal('ケベック州', subdivisions[:caqc])
+  end
+
+  test 'subdivisions for a non an unsupported locale :zz' do
+    subdivisions = Cldr::Export::Data::Subdivisions.new(:zz)
+
+    assert_empty(subdivisions)
+  end
+
+  test 'subdivisions locales are a subset of main locales' do
+    root = File.expand_path('./vendor/cldr/common')
+
+    main_locales = Dir["#{root}/main/*.xml"].map { |path| path =~ /([\w_-]+)\.xml/ && $1 }
+    subdivisions_locales = Dir["#{root}/subdivisions/*.xml"].map { |path| path =~ /([\w_-]+)\.xml/ && $1 }
+
+    assert_empty(subdivisions_locales - main_locales)
+  end
+
+ #
+ #   test "extract subdivisions for #{locale}" do
+ #     assert_nothing_raised do
+ #       Cldr::Export::Data::Subdivisions.new(locale)
+ #     end
+ #   end
+end


### PR DESCRIPTION
This PR exports the `subdivisions` (provinces, states, prefectures etc) from CLDR. :)

Essentially, we define a `Subdivisions` off `Base` and:
1. override `path` since subdivisions are defined off `{root}/subdivisions/` instead of `{root}/main/`
2. override `doc` to no-op the case where the locale xml doesn't exist. This is an issue when we export subdivisions on all locales, we do so using `Cldr::Export::Data.locales` which is defined off of `{root}/main/*`. I'm still using `main` locales as reference so I added a test to make sure the `subdivisions` locales < `main` locales.

I also made some updates because of failing tests:
1. Removed `en-GB` and `en-US` from `test languages :de` since those entries have been removed in CLDR 34
2. Made sure that all calls to `ParentLocales.new` provides an argument (even if not used)