### PR TITLE
Bring back root fallback for english

### DIFF
--- a/lib/cldr/export.rb
+++ b/lib/cldr/export.rb
@@ -144,12 +144,12 @@ module Cldr
             end
           end
 
-          ancestry << :root if component_should_merge_root?(component)
           ancestry 
         else
           [locale]
         end
 
+        locales << :root if should_merge_root?(locale, component, options)
         locales
       end
 
@@ -170,8 +170,10 @@ module Cldr
         SHARED_COMPONENTS.include?(component)
       end
 
-      def component_should_merge_root?(component)
-        !%w(Rbnf Fields).include?(component)
+      def should_merge_root?(locale, component, options)
+        return false if %w(Rbnf Fields).include?(component)
+        return true if options[:merge]
+        locale == :en
       end
     end
   end

--- a/test/export/data/calendars_test.rb
+++ b/test/export/data/calendars_test.rb
@@ -20,9 +20,25 @@ class TestCldrDataCalendars < Test::Unit::TestCase
         :abbreviated => { 1 => 'Jan', 2 => 'Feb', 3 => 'Mär', 4 => 'Apr', 5 => 'Mai', 6 => 'Jun', 7 => 'Jul', 8 => 'Aug', 9 => 'Sep', 10 => 'Okt', 11 => 'Nov', 12 => 'Dez' },
         :narrow => { 1 => 'J', 2 => 'F', 3 => 'M', 4 => 'A', 5 => 'M', 6 => 'J', 7 => 'J', 8 => 'A', 9 => 'S', 10 => 'O', 11 => 'N', 12 => 'D' },
         :wide => { 1 => 'Januar', 2 => 'Februar', 3 => 'März', 4 => 'April', 5 => 'Mai', 6 => 'Juni', 7 => 'Juli', 8 => 'August', 9 => 'September', 10 => 'Oktober', 11 => 'November', 12 => 'Dezember' },
-      }
+      },
     }
     assert_equal months, gregorian[:months]
+  end
+
+  test 'calendars months :en' do
+    months = {
+      :format => {
+        :abbreviated => { 1 => "Jan", 2 => "Feb", 3 => "Mar", 4 => "Apr", 5 => "May", 6 => "Jun", 7 => "Jul", 8 => "Aug", 9 => "Sep", 10 => "Oct", 11 => "Nov", 12 => "Dec" },
+        :narrow => :"calendars.gregorian.months.stand-alone.narrow",
+        :wide => { 1 => "January", 2 => "February", 3 => "March", 4 => "April", 5 => "May", 6 => "June", 7 => "July", 8 => "August", 9 => "September", 10 => "October", 11 => "November", 12 => "December" },
+      },
+      :"stand-alone" => {
+        :abbreviated => :"calendars.gregorian.months.format.abbreviated",
+        :narrow => { 1 => "J", 2 => "F", 3 => "M", 4 => "A", 5 => "M", 6 => "J", 7 => "J", 8 => "A", 9 => "S", 10 => "O", 11 => "N", 12 => "D" },
+        :wide => :"calendars.gregorian.months.format.wide",
+      },
+    }
+    assert_equal months, gregorian(locale: :en)[:months]
   end
 
   test 'calendars days :de' do


### PR DESCRIPTION
English language relies on root language data (ie. aliases), it seems to be the only one to do so (in my experience), so this fix should be ok.