### PR TITLE
Add a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,14 +24,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 - Added a changelog, [#49](https://github.com/ruby-i18n/ruby-cldr/pull/49)
+- Added Travis CI for testing, [#48](https://github.com/ruby-i18n/ruby-cldr/pull/48)
+- Added root fallback to en language, [#47](https://github.com/ruby-i18n/ruby-cldr/pull/47)
+- Added subdivisions to the list of exportable components, [#46](https://github.com/ruby-i18n/ruby-cldr/pull/46)
 
 ---
 
 ## [0.2.0] - 2019-03-26
 
-- Added Travis CI for testing, [#48](https://github.com/ruby-i18n/ruby-cldr/pull/48)
-- Added root fallback to en language, [#47](https://github.com/ruby-i18n/ruby-cldr/pull/47)
-- Added subdivisions to the list of exportable components, [#46](https://github.com/ruby-i18n/ruby-cldr/pull/46)
+- Updated to CLDR 34 [#43](https://github.com/ruby-i18n/ruby-cldr/pull/43)
+- Lots of [other changes](https://github.com/ruby-i18n/ruby-cldr/compare/v0.1.1...v0.2.0)
 
 [Unreleased]: https://github.com/ruby-i18n/ruby-cldr/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/ruby-i18n/ruby-cldr/compare/v0.1.1...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## How do I make a good changelog?
+### Guiding Principles
+- Changelogs are for humans, not machines.
+- There should be an entry for every single version.
+- The same types of changes should be grouped.
+- Versions and sections should be linkable.
+- The latest version comes first.
+- The release date of each version is displayed.
+- Mention whether you follow Semantic Versioning.
+
+### Types of changes
+- Added for new features.
+- Changed for changes in existing functionality.
+- Deprecated for soon-to-be removed features.
+- Removed for now removed features.
+- Fixed for any bug fixes.
+- Security in case of vulnerabilities.
+
+## [Unreleased]
+
+- Added a changelog, [#49](https://github.com/ruby-i18n/ruby-cldr/pull/49)
+
+---
+
+## [0.2.0] - 2019-03-26
+
+- Added Travis CI for testing, [#48](https://github.com/ruby-i18n/ruby-cldr/pull/48)
+- Added root fallback to en language, [#47](https://github.com/ruby-i18n/ruby-cldr/pull/47)
+- Added subdivisions to the list of exportable components, [#46](https://github.com/ruby-i18n/ruby-cldr/pull/46)
+
+[Unreleased]: https://github.com/ruby-i18n/ruby-cldr/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/ruby-i18n/ruby-cldr/compare/v0.1.1...v0.2.0


### PR DESCRIPTION
## What?

This PR adds a changelog so we can monitor the development process for this project.

It's following the convention established on [keepachangelog](https://keepachangelog.com/en/1.0.0/).

cc @Korri @froyomuffin 