### PR TITLE
Export currency names

### DIFF
--- a/lib/cldr/export/data/currencies.rb
+++ b/lib/cldr/export/data/currencies.rb
@@ -17,8 +17,16 @@ module Cldr
 
         def currency(node)
           data = select(node, 'displayName').inject({}) do |result, node|
-            count = node.attribute('count') ? node.attribute('count').value.to_sym : :one
-            result[count] = node.content unless draft?(node)
+            unless draft?(node)
+              if node.attribute('count')
+                count = node.attribute('count').value.to_sym
+                result[count] = node.content
+              else
+                result[:one] = node.content if result[:one].nil?
+                result[:name] = node.content
+              end
+            end
+
             result
           end
 

--- a/test/export/data/currencies_test.rb
+++ b/test/export/data/currencies_test.rb
@@ -36,7 +36,12 @@ class TestCldrCurrencies < Test::Unit::TestCase
     currencies = Cldr::Export::Data::Currencies.new('de')[:currencies]
     assert_empty codes - currencies.keys, "Unexpected missing currencies"
     assert_empty currencies.keys - codes, "Unexpected extra currencies"
-    assert_equal({ :one => 'Euro', :other => 'Euro', :symbol => '€' }, currencies[:EUR])
+    assert_equal({ :name => 'Euro', :one => 'Euro', :other => 'Euro', :symbol => '€' }, currencies[:EUR])
+  end
+
+  test 'currencies uses the label to populate :one when count is unavailable' do
+    currencies = Cldr::Export::Data::Currencies.new('ak')[:currencies]
+    assert_equal({ :name => 'Yuan', :one => 'Yuan' }, currencies[:CNY])
   end
 
   # Cldr::Export::Data.locales.each do |locale|


### PR DESCRIPTION
Presently, we're not exporting the currency labels from [CLDR data](https://github.com/unicode-org/cldr/blob/5271df0d065f81e742d3f4ff6d0c528359d07328/common/main/en.xml#L5680-L5685)

Essentially, we have two use cases for this data:
1. Render it with a number. Eg. 5 US dollars
2. Render it within a list. Eg. US Dollar, Euro, etc

The capitalization is different in both cases.

The currently export implementation simply exports data as `:one` and then overrides it with the actual `:one`. This PR just exports the data under `:name`.

I also added a test to check the case where we only have a 'displayName' node that we use that node's data to populate `:one`.