### PR TITLE
Support pluralization codes with missing spaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ before_script:
   - bundle exec thor cldr:download
 script:
   - bundle exec ruby test/all.rb
+
+before_install:
+  - gem install bundler

--- a/lib/cldr/export/data/plurals/rules.rb
+++ b/lib/cldr/export/data/plurals/rules.rb
@@ -57,6 +57,8 @@ module Cldr
             end
 
             def parse(code)
+              code = scrub_code(code)
+
               code = code.split('@').first.to_s
               operand = /(n|i|f|t|v|w)/i
               expr = /#{operand}(?:\s+(?:mod|%)\s+([\d]+))?/i
@@ -77,6 +79,15 @@ module Cldr
               else
                 raise "can not parse '#{code}'"
               end
+            end
+
+            private
+
+            def scrub_code(code)
+              code
+                .gsub(/(n)%(\d+)/, '\1 % \2') # n%1000 -> n % 1000
+                .gsub(/(\d+)=(\d+)/, '\1 = \2') # 10=100-> 10 = 100
+                .gsub(/(n)!=(\d+)/, '\1 != \2') # n!=100 -> n != 100
             end
           end
 

--- a/test/export/data/plurals_test.rb
+++ b/test/export/data/plurals_test.rb
@@ -176,11 +176,11 @@ class TestCldrDataPluralParser < Test::Unit::TestCase
     assert_equal false, eval(Cldr::Export::Data::Plurals::Rule.parse('n mod 100 in 3..6').to_ruby, binding)
   end
 
-	def test_codes_with_missing_spaces
+  def test_codes_with_missing_spaces
     assert_equal 'n.to_f % 100 == 0', Cldr::Export::Data::Plurals::Rule.parse('n%100 = 0').to_ruby
     assert_equal 'n.to_f % 100 == 0', Cldr::Export::Data::Plurals::Rule.parse('n % 100=0').to_ruby
     assert_equal 'n.to_f != 0', Cldr::Export::Data::Plurals::Rule.parse('n!=0').to_ruby
-	end
+  end
 
   def test_n_negative
     # one: i = 1 and v = 0 @integer 1

--- a/test/export/data/plurals_test.rb
+++ b/test/export/data/plurals_test.rb
@@ -176,6 +176,12 @@ class TestCldrDataPluralParser < Test::Unit::TestCase
     assert_equal false, eval(Cldr::Export::Data::Plurals::Rule.parse('n mod 100 in 3..6').to_ruby, binding)
   end
 
+	def test_codes_with_missing_spaces
+    assert_equal 'n.to_f % 100 == 0', Cldr::Export::Data::Plurals::Rule.parse('n%100 = 0').to_ruby
+    assert_equal 'n.to_f % 100 == 0', Cldr::Export::Data::Plurals::Rule.parse('n % 100=0').to_ruby
+    assert_equal 'n.to_f != 0', Cldr::Export::Data::Plurals::Rule.parse('n!=0').to_ruby
+	end
+
   def test_n_negative
     # one: i = 1 and v = 0 @integer 1
     # other: @integer 0, 2~16, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0~1.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …


### PR DESCRIPTION
In CLDR 35, the following was introduced:
https://github.com/unicode-org/cldr/blob/5271df0d065f81e742d3f4ff6d0c528359d07328/common/supplemental/plurals.xml#L228

Note the codes here often lack spaces. Eg. `n%1000 = 0`

This causes `Cldr::Export::Data::Plurals::Rule.parse` to fail as it uses regex relying on the spaces.

This PR adds a layer of scrubbing to add back the spaces.