### PR TITLE
Add in functionality to export country codes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,4 +80,4 @@ DEPENDENCIES
   thor
 
 BUNDLED WITH
-   2.0.1
+   2.1.4

--- a/lib/cldr/export.rb
+++ b/lib/cldr/export.rb
@@ -14,6 +14,7 @@ module Cldr
     autoload :Yaml, 'cldr/export/yaml'
 
     SHARED_COMPONENTS = %w[
+      CountryCodes
       CurrencyDigitsAndRounding
       Metazones
       NumberingSystems

--- a/lib/cldr/export/data.rb
+++ b/lib/cldr/export/data.rb
@@ -7,6 +7,7 @@ module Cldr
       autoload :Base,                      'cldr/export/data/base'
       autoload :Calendars,                 'cldr/export/data/calendars'
       autoload :Characters,                'cldr/export/data/characters'
+      autoload :CountryCodes,              'cldr/export/data/country_codes'
       autoload :Currencies,                'cldr/export/data/currencies'
       autoload :CurrencyDigitsAndRounding, 'cldr/export/data/currency_digits_and_rounding'
       autoload :Delimiters,                'cldr/export/data/delimiters'

--- a/lib/cldr/export/data/country_codes.rb
+++ b/lib/cldr/export/data/country_codes.rb
@@ -1,0 +1,29 @@
+module Cldr
+  module Export
+    module Data
+      class CountryCodes < Base
+        def initialize
+          super(nil)
+          update(:country_codes => country_codes)
+        end
+
+        private
+
+        def country_codes 
+          doc.xpath("//codeMappings/*").each_with_object({}) do |node, hash|
+            if node.name == "territoryCodes"
+              type = node.attribute('type').to_s.to_sym
+              hash[type] = {}
+              hash[type]["numeric"] = node[:numeric] if node[:numeric]
+              hash[type]["alpha3"] = node[:alpha3] if node[:alpha3]
+            end
+          end        
+        end
+
+        def path
+          @path ||= "#{Cldr::Export::Data.dir}/supplemental/supplementalData.xml"
+        end
+      end
+    end
+  end
+end

--- a/test/export/data/country_codes_test.rb
+++ b/test/export/data/country_codes_test.rb
@@ -1,0 +1,21 @@
+# encoding: utf-8
+
+require File.expand_path(File.join(File.dirname(__FILE__) + '/../../test_helper'))
+
+class TestCldrDataCountryCodes < Test::Unit::TestCase
+  test 'country codes' do
+    expected =
+      {
+        "AA": {
+          "numeric" => "958",
+          "alpha3" => "AAA",
+        },
+        "AC": {
+          "alpha3" => "ASC",
+        }
+      }
+    country_codes = Cldr::Export::Data::CountryCodes.new
+    assert_equal(country_codes[:country_codes][:AA], expected[:AA])
+    assert_equal(country_codes[:country_codes][:AC], expected[:AC])
+  end
+end

--- a/test/export/data/country_codes_test.rb
+++ b/test/export/data/country_codes_test.rb
@@ -6,11 +6,11 @@ class TestCldrDataCountryCodes < Test::Unit::TestCase
   test 'country codes' do
     expected =
       {
-        "AA": {
+        AA: {
           "numeric" => "958",
           "alpha3" => "AAA",
         },
-        "AC": {
+        AC: {
           "alpha3" => "ASC",
         }
       }


### PR DESCRIPTION
This PR exports country codes (two-letter country code mappings to three-digit letter and number codes), using the supplementalData.xml file from CLDR.

Following the existing shared data structure I have:
- Created a new country_codes.rb file for creating export data
- Added in required functionality to export.rb, data.rb
- Added in testing