### PR TITLE
Update CHANGELOG for PR #61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added Travis CI for testing, [#48](https://github.com/ruby-i18n/ruby-cldr/pull/48)
 - Added root fallback to en language, [#47](https://github.com/ruby-i18n/ruby-cldr/pull/47)
 - Added subdivisions to the list of exportable components, [#46](https://github.com/ruby-i18n/ruby-cldr/pull/46)
+- Added country codes as an exportable component, [#61](https://github.com/ruby-i18n/ruby-cldr/pull/61)
 
 ---
 


### PR DESCRIPTION
In a previous PR I added in the ability to export country codes from existing CLDR data, here https://github.com/ruby-i18n/ruby-cldr/pull/61.

In this PR I failed to update the Changelog, this PR fixes that.