### PR TITLE
Export narrow symbols from relevant currencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added root fallback to en language, [#47](https://github.com/ruby-i18n/ruby-cldr/pull/47)
 - Added subdivisions to the list of exportable components, [#46](https://github.com/ruby-i18n/ruby-cldr/pull/46)
 - Added country codes as an exportable component, [#61](https://github.com/ruby-i18n/ruby-cldr/pull/61)
+- Added narrow symbols to exported currency data, [#64](https://github.com/ruby-i18n/ruby-cldr/pull/64)
 
 ---
 

--- a/lib/cldr/export/data/currencies.rb
+++ b/lib/cldr/export/data/currencies.rb
@@ -31,7 +31,9 @@ module Cldr
           end
 
           symbol = select(node, 'symbol')
+          narrow_symbol = symbol.select { |child_node| child_node.values.include?('narrow') }.first
           data[:symbol] = symbol.first.content if symbol.length > 0
+          data[:'narrow_symbol'] = narrow_symbol.content unless narrow_symbol.nil?
 
           data
         end

--- a/test/export/data/currencies_test.rb
+++ b/test/export/data/currencies_test.rb
@@ -36,7 +36,12 @@ class TestCldrCurrencies < Test::Unit::TestCase
     currencies = Cldr::Export::Data::Currencies.new('de')[:currencies]
     assert_empty codes - currencies.keys, "Unexpected missing currencies"
     assert_empty currencies.keys - codes, "Unexpected extra currencies"
-    assert_equal({ :name => 'Euro', :one => 'Euro', :other => 'Euro', :symbol => '€' }, currencies[:EUR])
+    assert_equal({ :name => 'Euro', :'narrow_symbol'=>'€', :one => 'Euro', :other => 'Euro', :symbol => '€' }, currencies[:EUR])
+  end
+
+  test 'currencies populates symbol-narrow when narrow symbol is not equal to the regular symbol' do
+    currencies = Cldr::Export::Data::Currencies.new('root')[:currencies]
+    assert_equal({ :symbol=>'US$', :'narrow_symbol'=>'$'}, currencies[:USD])
   end
 
   test 'currencies uses the label to populate :one when count is unavailable' do


### PR DESCRIPTION
For some locales, the regular symbol pulled for currencies differs from the narrow symbol pulled for the same currencies. 

* e.g. the symbol for USD in en-AU is incorrectly exported as "USD". In CLDR, the narrow symbol for USD in the locale en-AU is defined up the tree in root.xml/en.xml. If we were to properly define that narrow-symbol in en.xml, an alternate valid symbol could be created in the edge case where the regular symbol does not suffice.
* e.g. reference https://github.com/unicode-org/cldr/blob/f7d6d55ca3073b209d3bf2dd9fcf15d28c259e16/common/main/en_AU.xml#L6297
 
The narrow symbols can be extracted from CLDR to better define currency symbols for the edge cases where the regular currency pulled from CLDR is not sufficient. If narrow-symbol isn't defined in the current locale, the user can check the parent locale for the narrow symbol, and so on up to root.xml

Changes:
  - Export narrow currency symbols for all locales.
  - Add in testing