### PR TITLE
Only export `plurals.rb` for those that have plurals data

### DIFF
--- a/lib/cldr/export.rb
+++ b/lib/cldr/export.rb
@@ -108,7 +108,7 @@ module Cldr
 
       def plural_data(component, locale, options = {})
         data = locale_based_data(component, locale, options)
-        "{ :'#{locale}' => { :i18n => { :plural => { :keys => #{data[:keys].inspect}, :rule => #{data[:rule]} } } } }"
+        data.empty? ? "" : "{ :'#{locale}' => { :i18n => { :plural => { :keys => #{data[:keys].inspect}, :rule => #{data[:rule]} } } } }"
       end
 
       def shared_data(component, options = {})
@@ -145,7 +145,7 @@ module Cldr
             end
           end
 
-          ancestry 
+          ancestry
         else
           [locale]
         end

--- a/test/export_test.rb
+++ b/test/export_test.rb
@@ -26,6 +26,14 @@ class TestExtract < Test::Unit::TestCase
     assert_equal 'NaN', data[:numbers][:symbols][:nan]
   end
 
+  test 'passing the merge option generates and merges Plurals data from fallback locales' do
+    data = Cldr::Export.data('Plurals', 'af-NA')
+    assert_equal "", data
+
+    data = Cldr::Export.data('Plurals', 'af-NA', :merge => true)
+    assert_match(/{ :'af-NA' => { :i18n => { :plural/, data)
+  end
+
   test 'the merge option respects parentLocales' do
     data = Cldr::Export.data('calendars', 'en-GB', :merge => true)
     assert_equal 'dd/MM/y', data[:calendars][:gregorian][:additional_formats]['yMd']


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #70

I _think_ that the user's expectation is that `ruby-cldr` would not output a `plurals.rb` unless the `--merge` option is passed:

> By default this library just exports data that is present in CLDR for a given locale. If you do not want to use locale fallbacks in your application you’ll need to “flatten” locale fallbacks and merge the data during export time. To do that you can use the `--merge` option:
-https://github.com/ruby-i18n/ruby-cldr#export

### What approach did you choose and why?

I changed `plurals_data` to return an empty string in cases where there is no `locale_based_data`.
I find it somewhat weird that `plurals_data` returns a `String`, but I kept the type signature instead of returning a non-`String`.

[`Cldr::Export::Ruby` then checks `data.empty?`](https://github.com/movermeyer/ruby-cldr/blob/79c1cb5aa0082430f753f1b122ba22e548d1ab69/lib/cldr/export/ruby.rb#L7) before outputting `.rb` files, including `plurals.rb`. Therefore, returning an empty string means that the `plurals.rb` file is not created for the locale. 

### What should reviewers focus on?

🤷 IDK.

### The impact of these changes

Fixes #70. `ruby-cldr` will stop outputting invalid `plurals.rb` files. 