### PR TITLE
Correct bad locale fallback tests

### DIFF
--- a/test/export_test.rb
+++ b/test/export_test.rb
@@ -4,7 +4,7 @@ require File.dirname(__FILE__) + '/test_helper.rb'
 require 'yaml'
 require 'fileutils'
 
-class TestExtract < Test::Unit::TestCase
+class TestExport < Test::Unit::TestCase
   def setup
     Cldr::Export.base_path = tmp_dir
     FileUtils.mkdir_p(tmp_dir) rescue nil
@@ -91,12 +91,12 @@ class TestExtract < Test::Unit::TestCase
 
   test "#locales does not fall back to English (unless the locale is English based)" do
     assert_equal [:ko, :root], Cldr::Export.locales('ko', 'numbers', :merge => true)
-    assert_equal [:'pt-br', :pt, :root], Cldr::Export.locales('pt-br', 'numbers', :merge => true)
-    assert_equal [:'en-gb', :en, :root], Cldr::Export.locales('en-gb', 'numbers', :merge => true)
+    assert_equal [:'pt-BR', :pt, :root], Cldr::Export.locales('pt_BR', 'numbers', :merge => true)
+    assert_equal [:'en-GB', :'en-001', :en, :root], Cldr::Export.locales('en_GB', 'numbers', :merge => true)
   end
 
   test "#locales does not fall back if :merge option is false" do
-    assert_equal [:'pt-br'], Cldr::Export.locales('pt-br', 'numbers', :merge => false)
+    assert_equal [:'pt-BR'], Cldr::Export.locales('pt_BR', 'numbers', :merge => false)
   end
 
   # Cldr::Export::Data.locales.each do |locale|


### PR DESCRIPTION
The example locales provided as parameters in the test are not representative of the locales that `Export#locales` is called with.

This means that they were never matching any `Cldr::Export::Data::ParentLocales`, which made the expected results incorrect.

---

CLDR defines `parentLocales` using locales that look like:

```xml
<parentLocale parent="pt_PT" locales="pt_AO pt_CH pt_CV pt_FR pt_GQ pt_GW pt_LU pt_MO pt_MZ pt_ST pt_TL"/>
```

Note that it uses `_` as the separator, and the "country" codes are uppercase. [This has always been the case](https://github.com/unicode-org/cldr/commit/6c0de5764674192f20f919aaa83f2e68bc98a530)

`Cldr::Export::Data::ParentLocales` maintains this casing (and always has):

```ruby
(byebug) Cldr::Export::Data::ParentLocales.new.select { |locale, parent| parent == "pt_PT" }
{"pt_AO"=>"pt_PT", "pt_CH"=>"pt_PT", "pt_CV"=>"pt_PT", "pt_FR"=>"pt_PT", "pt_GQ"=>"pt_PT", "pt_GW"=>"pt_PT", "pt_LU"=>"pt_PT", "pt_MO"=>"pt_PT", "pt_MZ"=>"pt_PT", "pt_ST"=>"pt_PT", "pt_TL"=>"pt_PT"}
```

However, these tests were passing in "hyphen separated, all lowercase" versions of the locales, which meant that they never matched anything in `Cldr::Export::Data::ParentLocales`.

---

### What are you trying to accomplish?

Correct the tests to have parameters that are representative of how `Export#locales` is actually called.

### What approach did you choose and why?

Changed the parameters of the tests to match the format actually used.
You can verify that this is the format used by adding a `puts(locale)` as the first line of `Export#locales` and running `thor cldr:download`.

I then updated the expected fallback chain of `en-GB` to match the new resulting chain. 

### What should reviewers focus on?

🤷

I _think_ that the current fallback chain for `en-GB` is correct. 

### The impact of these changes

This doesn't change the current behaviour, but just fixes the tests.

### Checklist
- [x] This PR is safe to roll back.
