### PR TITLE
Remove the special casing of `one` key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Only export plurals.rb for those that have plurals data, [#71](https://github.com/ruby-i18n/ruby-cldr/pull/71)
+
 ---
 
 ## [0.5.0] - 2020-11-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 - Only export plurals.rb for those that have plurals data, [#71](https://github.com/ruby-i18n/ruby-cldr/pull/71)
+- Only export plural keys for currencies that have pluralization data, [80](https://github.com/ruby-i18n/ruby-cldr/pull/80)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,22 +25,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
-## [0.2.0] - 2019-03-26
-
-- Updated to CLDR 34 [#43](https://github.com/ruby-i18n/ruby-cldr/pull/43)
-- Lots of [other changes](https://github.com/ruby-i18n/ruby-cldr/compare/v0.1.1...v0.2.0)
-
-## [0.3.0] - 2019-06-16
-
-- Export currency names [#51](https://github.com/ruby-i18n/ruby-cldr/pull/51)
-- Bring back root fallback for english [#47](https://github.com/ruby-i18n/ruby-cldr/pull/47)
-- Export subdivisions [#46](https://github.com/ruby-i18n/ruby-cldr/pull/46)
-
-## [0.4.0] - 2020-09-01
-
-- Support pluralization codes with missing spaces [#53](https://github.com/ruby-i18n/ruby-cldr/pull/53)
-- Add in functionality to export country codes [#61](https://github.com/ruby-i18n/ruby-cldr/pull/61)
-
 ## [0.5.0] - 2020-11-20
 
 - Added a changelog, [#49](https://github.com/ruby-i18n/ruby-cldr/pull/49)
@@ -49,5 +33,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added subdivisions to the list of exportable components, [#46](https://github.com/ruby-i18n/ruby-cldr/pull/46)
 - Added country codes as an exportable component, [#61](https://github.com/ruby-i18n/ruby-cldr/pull/61)
 - Added narrow symbols to exported currency data, [#64](https://github.com/ruby-i18n/ruby-cldr/pull/64)
+
+## [0.4.0] - 2020-09-01
+
+- Support pluralization codes with missing spaces [#53](https://github.com/ruby-i18n/ruby-cldr/pull/53)
+- Add in functionality to export country codes [#61](https://github.com/ruby-i18n/ruby-cldr/pull/61)
+
+## [0.3.0] - 2019-06-16
+
+- Export currency names [#51](https://github.com/ruby-i18n/ruby-cldr/pull/51)
+- Bring back root fallback for english [#47](https://github.com/ruby-i18n/ruby-cldr/pull/47)
+- Export subdivisions [#46](https://github.com/ruby-i18n/ruby-cldr/pull/46)
+
+## [0.2.0] - 2019-03-26
+
+- Updated to CLDR 34 [#43](https://github.com/ruby-i18n/ruby-cldr/pull/43)
+- Lots of [other changes](https://github.com/ruby-i18n/ruby-cldr/compare/v0.1.1...v0.2.0)
 
 [Unreleased]: https://github.com/ruby-i18n/ruby-cldr/compare/v0.5.0...HEAD

--- a/lib/cldr/export/data/currencies.rb
+++ b/lib/cldr/export/data/currencies.rb
@@ -22,7 +22,6 @@ module Cldr
                 count = node.attribute('count').value.to_sym
                 result[count] = node.content
               else
-                result[:one] = node.content if result[:one].nil?
                 result[:name] = node.content
               end
             end

--- a/test/export/data/currencies_test.rb
+++ b/test/export/data/currencies_test.rb
@@ -44,11 +44,6 @@ class TestCldrCurrencies < Test::Unit::TestCase
     assert_equal({ :symbol=>'US$', :'narrow_symbol'=>'$'}, currencies[:USD])
   end
 
-  test 'currencies uses the label to populate :one when count is unavailable' do
-    currencies = Cldr::Export::Data::Currencies.new('ak')[:currencies]
-    assert_equal({ :name => 'Yuan', :one => 'Yuan' }, currencies[:CNY])
-  end
-
   # Cldr::Export::Data.locales.each do |locale|
   #   test "extract currencies for #{locale}" do
   #     assert_nothing_raised do


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes https://github.com/ruby-i18n/ruby-cldr/issues/76

If the CLDR locale data doesn't have pluralization data for the currency:

a) We shouldn't make it up
b) `one` is not a valid pluralization key in most languages
c) Often pluralization keys other than `one` are needed

See https://github.com/ruby-i18n/ruby-cldr/issues/76 for the full context

### What approach did you choose and why?

Simple removal of the key.

I also had to fix the `CHANGELOG` to be able to include a note on this change. It was sorted backwards from what [Keep a Changelog](https://keepachangelog.com/) specifies, and it was missing an entry for my [previous change](https://github.com/ruby-i18n/ruby-cldr/pull/71).

### What should reviewers focus on?

🤷 I've documented the change, and `ruby-cldr` is pre-`1.0.0`, so ["Anything MAY change at any time"](https://semver.org/).

### The impact of these changes

Consumers may have to update their code if they were relying on this key's existence.
`ruby-cldr` will no longer be making up data in this case. 👍 

### Testing

1. Run `thor cldr:export --components currencies`
2. Open `data/af/currencies.yml`

Note that there is no longer any `one` key for `LVL`, since there is no `one` key for `LVL` in the [CLDR data](https://github.com/unicode-org/cldr/blob/4b87f2d718dd9cab45517ebe7f996ac10b6b1fff/common/main/af.xml#L5405-L5408).