### PR TITLE
Sort the exported YAML data by key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Only export plurals.rb for those that have plurals data, [#71](https://github.com/ruby-i18n/ruby-cldr/pull/71)
 - Only export plural keys for currencies that have pluralization data, [80](https://github.com/ruby-i18n/ruby-cldr/pull/80)
+- Sort the exported data by key, [82](https://github.com/ruby-i18n/ruby-cldr/pull/82)
 
 ---
 

--- a/lib/cldr/export.rb
+++ b/lib/cldr/export.rb
@@ -5,6 +5,7 @@ require 'core_ext/string/camelize'
 require 'core_ext/string/underscore'
 require 'core_ext/hash/deep_stringify_keys'
 require 'core_ext/hash/deep_merge'
+require 'core_ext/hash/deep_sort'
 
 module Cldr
   module Export

--- a/lib/cldr/export/yaml.rb
+++ b/lib/cldr/export/yaml.rb
@@ -8,6 +8,7 @@ module Cldr
         data = Export.data(component, locale, options)
         unless data.empty?
           data = data.deep_stringify_keys if data.respond_to?(:deep_stringify_keys)
+          data = data.deep_sort if data.respond_to?(:deep_sort)
           data = { locale.to_s.gsub('_', '-') => data } if locale != ""
           path = Export.path(locale, component, 'yml')
           Export.write(path, yaml(data))

--- a/lib/core_ext/hash/deep_sort.rb
+++ b/lib/core_ext/hash/deep_sort.rb
@@ -1,0 +1,82 @@
+# Copied from https://github.com/mcrossen/deepsort/blob/786fe3dd35980f028c0842797d25b27e53cd95f8/lib/deepsort.rb
+# MIT licensed
+
+# -----
+#
+# MIT License
+#
+# Copyright (c) 2016 Mark Crossen
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# -----
+
+module DeepSort
+  module DeepSortHash
+    def deep_sort(options = {})
+      deep_sort_by(options) { |obj| obj }
+    end
+
+    def deep_sort!(options = {})
+      deep_sort_by!(options) { |obj| obj }
+    end
+
+    def deep_sort_by(options = {}, &block)
+      hash = self.map do |key, value|
+        [if key.respond_to?(:deep_sort_by)
+          key.deep_sort_by(options, &block)
+        else
+          key
+        end,
+
+        if value.respond_to?(:deep_sort_by)
+          value.deep_sort_by(options, &block)
+        else
+          value
+        end]
+      end
+
+      Hash[options[:hash] == false ? hash : hash.sort_by(&block)]
+    end
+
+    def deep_sort_by!(options = {}, &block)
+      hash = self.map do |key, value|
+        [if key.respond_to?(:deep_sort_by!)
+          key.deep_sort_by!(options, &block)
+        else
+          key
+        end,
+
+        if value.respond_to?(:deep_sort_by!)
+          value.deep_sort_by!(options, &block)
+        else
+          value
+        end]
+      end
+      replace(Hash[options[:hash] == false ? hash : hash.sort_by!(&block)])
+    end
+
+    # comparison for hashes is ill-defined. this performs array or string comparison if the normal comparison fails.
+    def <=>(other)
+      super(other) || to_a <=> other.to_a || to_s <=> other.to_s
+    end
+  end
+end
+
+Hash.send(:include, DeepSort::DeepSortHash)

--- a/ruby-cldr.gemspec
+++ b/ruby-cldr.gemspec
@@ -103,6 +103,7 @@ Gem::Specification.new do |s|
     "test/export/data/timezones_test.rb",
     "test/export/data/units_test.rb",
     "test/export/data/windows_zones_test.rb",
+    "test/export/yaml_test.rb",
     "test/export_test.rb",
     "test/format/all.rb",
     "test/format/currency_test.rb",

--- a/test/export/yaml_test.rb
+++ b/test/export/yaml_test.rb
@@ -1,0 +1,26 @@
+# encoding: utf-8
+
+require File.expand_path(File.join(File.dirname(__FILE__) + '/../test_helper'))
+
+class TestYaml < Test::Unit::TestCase
+  test 'Hash values are deep sorted' do
+    data = Cldr::Export::Yaml.new.export('fr', 'currencies', :merge => true)
+    assert_equal deep_flatten(data.deep_sort).to_a, deep_flatten(data).to_a
+  end
+
+  private
+
+  def deep_flatten(hash, output = {}, parent_key = [])
+    hash.keys.each do |key|
+      current_key = parent_key + [key]
+
+      if hash[key].is_a?(Hash)
+        deep_flatten(hash[key], output, current_key)
+      else
+        output[current_key] = hash[key]
+      end
+    end
+
+    output
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes https://github.com/ruby-i18n/ruby-cldr/issues/81

Sort the output for cleaner line-by-line diffs.
Also, the outputted key order won't change when we change internal implementation details (as it did in #80).

### What approach did you choose and why?

I vendored a bit of code from the [`deepsort`](https://github.com/mcrossen/deepsort) gem to allow for simple sorting of nested hashes by key.

I then called `deep_sort` after the call to `deep_stringify_keys` (since `deep_sort` doesn't work if the keys are a mix of symbols and strings).

### What should reviewers focus on?

🤷

Note that this sorts every level of keys in the exported YAML data.
For anyone parsing the data, their code will be unaffected, as the YAML spec specifies that [order in mappings is a serialization detail](https://yaml.org/spec/1.2.2/#3221-mapping-key-order).

`deepsort` is also MIT licensed. I've included the necessary copyright and license notes in the file.

### The impact of these changes

All "shared" and "locale" data is now sorted by key.

### Testing

```
thor cldr:export --locales fr --components currencies
```

```
thor cldr:export --locales fr --components currencies --merge
```

Now produce the exact same file (`data/fr/currencies.yml`). See #81 for details.