### PR TITLE
Remove defaults and stop outputting fake data

### DIFF
--- a/lib/cldr/export/data/calendars/gregorian.rb
+++ b/lib/cldr/export/data/calendars/gregorian.rb
@@ -91,11 +91,13 @@ module Cldr
               keys.inject({}) do |result, name|
                 path = "#{base_path}/#{name}/*"
                 key  = name.gsub('era', '').gsub(/s$/, '').downcase.to_sym
-                result[key] = select(path).inject({}) do |ret, node|
-                  type = node.attribute('type').value.to_i rescue 0
+                key_result = select(path).inject({}) do |ret, node|
+                  next ret if node.name == "alias" # TODO: Actually handle alias nodes, https://github.com/ruby-i18n/ruby-cldr/issues/78
+                  type = node.attribute('type').value.to_i
                   ret[type] = node.content
                   ret
                 end
+                result[key] = key_result unless key_result.empty?
                 result
               end
             else

--- a/lib/cldr/export/data/calendars/gregorian.rb
+++ b/lib/cldr/export/data/calendars/gregorian.rb
@@ -62,14 +62,14 @@ module Cldr
               end
             end
           end
-        
+
           def xpath_to_key(xpath, kind, context, width)
             kind    = (xpath =~ %r(/([^\/]*)Width) && $1) || kind
             context = (xpath =~ %r(Context\[@type='([^\/]*)'\]) && $1) || context
             width   = (xpath =~ %r(Width\[@type='([^\/]*)'\]) && $1) || width
             :"calendars.gregorian.#{kind}s.#{context}.#{width}"
           end
-        
+
           def xpath_width
           end
 
@@ -114,7 +114,7 @@ module Cldr
 
           def formats(type)
             formats = select(calendar, "#{type}Formats/#{type}FormatLength").inject({}) do |result, node|
-              key = node.attribute('type').value.to_sym rescue :format
+              key = node.attribute('type').value.to_sym
               result[key] = pattern(node, type)
               result
             end

--- a/lib/cldr/export/data/numbers.rb
+++ b/lib/cldr/export/data/numbers.rb
@@ -107,7 +107,7 @@ module Cldr
 
         def unit
           @unit ||= select("numbers/currencyFormats/unitPattern").inject({}) do |result, node|
-            count = node.attribute('count').value rescue 'one'
+            count = node.attribute('count').value
             result[count] = node.content
             result
           end

--- a/test/export/data/calendars_test.rb
+++ b/test/export/data/calendars_test.rb
@@ -196,6 +196,17 @@ class TestCldrDataCalendars < Test::Unit::TestCase
     assert_equal %w(abbreviated narrow wide), gregorian(:merged => true)[:months][:"stand-alone"].keys.map { |key| key.to_s }.sort
   end
 
+  test 'calendars for :root only contains `abbr` since we do not yet handle alias nodes' do
+    # https://github.com/ruby-i18n/ruby-cldr/issues/78
+    eras = {
+      abbr: {
+        0 => "BCE",
+        1 => "CE",
+      }
+    }
+    assert_equal eras, gregorian(locale: :root)[:eras]
+  end
+
   # Cldr::Export::Data.locales.each do |locale|
   #   test "extract calendars for #{locale}" do
   #     Cldr::Export::Data::Calendars.new(locale)


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #87. Removing defaults that would be incorrect if used.

### What approach did you choose and why?

These commits remove unnecessary defaults. There are no instances of these attributes missing in the CLDR data, so there is no impact on the data exported by `ruby-cldr`.
In all but one case, the attributes are already required attributes (in the [`ldml.dtd`](https://github.com/unicode-org/cldr-staging/blob/85fa5bd46a9c83d2d6e10c4cee1f79f5de0838d0/production/common/dtd/ldml.dtd) schema), so there is no way they could be missing.

In the one case where the attribute is not a required attribute (`type` on `dateTimeFormatLength`), it was defaulting to a value that is not valid (`:format`). Once again, there are no current instances of a `dateTimeFormatLength` without a `type` attribute. In the rare case there were to ever be one, I'd rather have the export fail than silently pass with an invalid default value.

There are two instances in `root` where `<alias>` nodes were being handled incorrectly. Those keys are removed from the output by this change. See [this comment](https://github.com/ruby-i18n/ruby-cldr/pull/88/files#r749563222) for explanation.

### What should reviewers focus on?

🤷

Note that this doesn't solve the problem of mixing number systems (#89).

### The impact of these changes

* Gets rid of defaults that would be dangerous if they were used.
* Gets rid two incorrect data from `root` as a result of not following aliases.

### Testing

You could run `thor cldr:export` for `master` and this branch, then run `diff -r` to compare the outputs:

```bash
git checkout master
thor cldr:export --target=./data_from_master

git checkout movermeyer:mo.stop_outputting_fake_data
thor cldr:export --target=./data_from_pr

diff -r data_from_master data_from_pr
```

Which outputs:

```diff
diff -r data_from_master/root/calendars.yml data_from_pr/root/calendars.yml
81,84d80
<         name:
<           0: ''
<         narrow:
<           0: ''
```

