### PR TITLE
Output parent locales once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Only export plural keys for currencies that have pluralization data, [#80](https://github.com/ruby-i18n/ruby-cldr/pull/80)
 - Sort the exported data by key, [#82](https://github.com/ruby-i18n/ruby-cldr/pull/82)
 - Prune empty hashes / files before outputting, [#86](https://github.com/ruby-i18n/ruby-cldr/pull/86)
+- Re-add the `ParentLocales` component, this time as a shared component, [#91](https://github.com/ruby-i18n/ruby-cldr/pull/91)
 
 ---
 

--- a/lib/cldr/export.rb
+++ b/lib/cldr/export.rb
@@ -16,19 +16,19 @@ module Cldr
     autoload :Yaml, 'cldr/export/yaml'
 
     SHARED_COMPONENTS = %w[
+      Aliases
       CountryCodes
       CurrencyDigitsAndRounding
+      LikelySubtags
       Metazones
       NumberingSystems
       RbnfRoot
+      RegionCurrencies
       SegmentsRoot
       TerritoriesContainment
-      WindowsZones
       Transforms
-      LikelySubtags
       Variables
-      Aliases
-      RegionCurrencies
+      WindowsZones
     ]
 
     class << self

--- a/lib/cldr/export.rb
+++ b/lib/cldr/export.rb
@@ -22,6 +22,7 @@ module Cldr
       LikelySubtags
       Metazones
       NumberingSystems
+      ParentLocales
       RbnfRoot
       RegionCurrencies
       SegmentsRoot

--- a/lib/cldr/export/data.rb
+++ b/lib/cldr/export/data.rb
@@ -49,7 +49,7 @@ module Cldr
         end
 
         def components
-          self.constants.sort - [:Base, :Export, :ParentLocales]
+          self.constants.sort - [:Base, :Export]
         end
       end
     end


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #90 

### What approach did you choose and why?

* Sorted the list of shared components
* Added the `ParentLocales` to the list of shared locales
* Brought back `ParentLocales` in `Cldr::Export::Data#components` (effectively reverting #40) 

When `ParentLocales` [was added](https://github.com/ruby-i18n/ruby-cldr/pull/38), it was added as a locale-based component, but didn't have the same signature of locale-based components (since of course it is a shared component), so it caused [an error](https://github.com/ruby-i18n/ruby-cldr/pull/38#issuecomment-306159358). This was fixed in IMO the wrong way in #40, by excluding the component from being exported unless explicitly requested.

This brings back the component, and now that it is properly marked as a shared component, it no longer has that error.

### What should reviewers focus on?

🤷 

### The impact of these changes

* `ParentLocales` is once again exported by default (users of `ruby-cldr` no longer have to run `thor cldr:export` and `thor cldr:export --components=parentLocales`, but instead just the former)
* `parent_locales.yml` is output in `data/` and not under each locale directory.
* Less files, less bytes:

|                   | Before (with explicit `--components=parentLocales`) | After | Ratio |
| ----------------- | ------ | ----- | ----- |
| # of `.yml` files | 6476   | 5723  | 0.88  |
| Total bytes       | 30753892 (29.3 MiB) | 28984221 (27.6 MiB) | 0.94  |


### Testing

```
thor cldr:export
```

See that `data/parent_locales.yml` exists and contains the same data.