### PR TITLE
Merge data files before lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Re-add the `ParentLocales` component, this time as a shared component, [#91](https://github.com/ruby-i18n/ruby-cldr/pull/91)
 - Changed the keys and values of `ParentLocales` component to be symbols, [#101](https://github.com/ruby-i18n/ruby-cldr/pull/101)
 - Fixed bug with fallbacks for locales that had more than two segments, [#101](https://github.com/ruby-i18n/ruby-cldr/pull/101)
+- Merge all the related data files before doing lookups, [#98](https://github.com/ruby-i18n/ruby-cldr/pull/98)
 
 ---
 

--- a/lib/cldr/export/data.rb
+++ b/lib/cldr/export/data.rb
@@ -51,6 +51,10 @@ module Cldr
         def components
           self.constants.sort - [:Base, :Export]
         end
+
+        def paths_by_root
+          @paths ||= Dir[File.join(dir, "**", "*.xml")].sort.group_by { |path| Nokogiri::XML(File.read(path)).root.name }
+        end
       end
     end
   end

--- a/lib/cldr/export/data/aliases.rb
+++ b/lib/cldr/export/data/aliases.rb
@@ -36,11 +36,6 @@ module Cldr
             ret
           end
         end
-
-        def path
-          @path ||= "#{Cldr::Export::Data.dir}/supplemental/supplementalMetadata.xml"
-        end
-
       end
     end
   end

--- a/lib/cldr/export/data/base.rb
+++ b/lib/cldr/export/data/base.rb
@@ -8,6 +8,8 @@ module Cldr
       class Base < Hash
         attr_reader :locale
 
+        @@doc_cache = {}
+
         def initialize(locale)
           @locale = locale
         end
@@ -53,11 +55,45 @@ module Cldr
           end
 
           def doc
-            @doc ||= Nokogiri::XML(File.read(path))
+            @@doc_cache[paths.hash] ||= merge_paths(paths)
           end
 
-          def path
-            @path ||= "#{Cldr::Export::Data.dir}/main/#{Cldr::Export.from_i18n(locale)}.xml"
+          def paths
+            @paths ||= begin
+              if locale
+                Dir[File.join(Cldr::Export::Data.dir, "*", "#{Cldr::Export.from_i18n(locale)}.xml")].sort & Cldr::Export::Data.paths_by_root["ldml"]
+              else
+                Cldr::Export::Data.paths_by_root["supplementalData"]
+              end
+            end
+          end
+
+          private
+
+          def merge_paths(paths_to_merge)
+            # Some parts (`ldml`, `ldmlBCP47` amd `supplementalData`) of CLDR data require that you merge all the
+            # files with the same root element before doing lookups.
+            # Ref: https://www.unicode.org/reports/tr35/tr35.html#XML_Format
+            #
+            # The return of this method is a merged XML Nokogiri document.
+            # Note that it technically is no longer compliant with the CLDR `ldml.dtd`, since:
+            # * it has repeated elements
+            # * the <identity> elements no longer refer to the filename
+            #
+            # However, this is not an issue, since #select will find all of the matches from each of the repeated elements,
+            # and the <identity> elements are not important to us / make no sense when combined together.
+            return Nokogiri::XML('') if paths_to_merge.empty?
+
+            rest = paths_to_merge[1..paths_to_merge.size - 1]
+            rest.inject(Nokogiri::XML(File.read(paths_to_merge.first))) do |result, path|
+              next_doc = Nokogiri::XML(File.read(path))
+
+              next_doc.root.children.each do |child|
+                result.root.add_child(child)
+              end
+
+              result
+            end
           end
       end
     end

--- a/lib/cldr/export/data/country_codes.rb
+++ b/lib/cldr/export/data/country_codes.rb
@@ -9,7 +9,7 @@ module Cldr
 
         private
 
-        def country_codes 
+        def country_codes
           doc.xpath("//codeMappings/*").each_with_object({}) do |node, hash|
             if node.name == "territoryCodes"
               type = node.attribute('type').to_s.to_sym
@@ -17,11 +17,7 @@ module Cldr
               hash[type]["numeric"] = node[:numeric] if node[:numeric]
               hash[type]["alpha3"] = node[:alpha3] if node[:alpha3]
             end
-          end        
-        end
-
-        def path
-          @path ||= "#{Cldr::Export::Data.dir}/supplemental/supplementalData.xml"
+          end
         end
       end
     end

--- a/lib/cldr/export/data/likely_subtags.rb
+++ b/lib/cldr/export/data/likely_subtags.rb
@@ -18,11 +18,6 @@ module Cldr
             ret
           end
         end
-
-        def path
-          @path ||= "#{Cldr::Export::Data.dir}/supplemental/likelySubtags.xml"
-        end
-
       end
     end
   end

--- a/lib/cldr/export/data/numbering_systems.rb
+++ b/lib/cldr/export/data/numbering_systems.rb
@@ -30,11 +30,6 @@ module Cldr
             ret
           end
         end
-
-        def path
-          @path ||= "#{Cldr::Export::Data.dir}/supplemental/numberingSystems.xml"
-        end
-
       end
     end
   end

--- a/lib/cldr/export/data/rbnf.rb
+++ b/lib/cldr/export/data/rbnf.rb
@@ -11,17 +11,16 @@ module Cldr
         end
 
         def rule_groups
-          if File.exist?(path)
-            select("rbnf/rulesetGrouping").map do |grouping_node|
-              {
-                :type => grouping_node.attribute("type").value,
-                :ruleset => (grouping_node / "ruleset").map do |ruleset_node|
-                  rule_set(ruleset_node)
-                end
-              }
-            end
-          else
-            {}
+          grouping_nodes = select("rbnf/rulesetGrouping")
+          return {} if grouping_nodes.empty?
+
+          grouping_nodes.map do |grouping_node|
+            {
+              :type => grouping_node.attribute("type").value,
+              :ruleset => (grouping_node / "ruleset").map do |ruleset_node|
+                rule_set(ruleset_node)
+              end
+            }
           end
         end
 
@@ -61,11 +60,6 @@ module Cldr
         def fix_rule(rule)
           rule.gsub(/\A'/, '').gsub("←", '<').gsub("→", '>')
         end
-
-        def path
-          @path ||= "#{Cldr::Export::Data.dir}/rbnf/#{Cldr::Export.from_i18n(locale)}.xml"
-        end
-
       end
     end
   end

--- a/lib/cldr/export/data/rbnf_root.rb
+++ b/lib/cldr/export/data/rbnf_root.rb
@@ -9,8 +9,8 @@ module Cldr
 
         private
 
-        def path
-          @path ||= "#{Cldr::Export::Data.dir}/rbnf/root.xml"
+        def paths
+          @paths ||= [File.join(Cldr::Export::Data.dir, "rbnf", "root.xml")]
         end
 
       end

--- a/lib/cldr/export/data/region_currencies.rb
+++ b/lib/cldr/export/data/region_currencies.rb
@@ -34,11 +34,6 @@ module Cldr
             result
           end
         end
-
-        def path
-          @path ||= "#{Cldr::Export::Data.dir}/supplemental/supplementalData.xml"
-        end
-
       end
     end
   end

--- a/lib/cldr/export/data/segments_root.rb
+++ b/lib/cldr/export/data/segments_root.rb
@@ -41,8 +41,8 @@ module Cldr
           end
         end
 
-        def path
-          @path ||= "#{Cldr::Export::Data.dir}/segments/root.xml"
+        def paths
+          @paths ||= ["#{Cldr::Export::Data.dir}/segments/root.xml"]
         end
 
         def cast_value(value)

--- a/lib/cldr/export/data/subdivisions.rb
+++ b/lib/cldr/export/data/subdivisions.rb
@@ -16,19 +16,6 @@ module Cldr
             result
           end
         end
-
-        def doc
-          begin
-            super
-          rescue Errno::ENOENT
-            @doc = Nokogiri::XML('')
-          end
-        end
-
-        def path
-          @path ||= "#{Cldr::Export::Data.dir}/subdivisions/#{Cldr::Export.from_i18n(locale)}.xml"
-        end
-
       end
     end
   end

--- a/lib/cldr/export/data/transforms.rb
+++ b/lib/cldr/export/data/transforms.rb
@@ -66,8 +66,8 @@ module Cldr
             gsub("↔", '<>')
         end
 
-        def path
-          transform_file
+        def paths
+          [transform_file]
         end
 
       end

--- a/lib/cldr/export/data/variables.rb
+++ b/lib/cldr/export/data/variables.rb
@@ -31,11 +31,6 @@ module Cldr
         def split_value_list(value_list)
           value_list.strip.split(/[\s]+/)
         end
-
-        def path
-          @path ||= "#{Cldr::Export::Data.dir}/supplemental/supplementalMetadata.xml"
-        end
-
       end
     end
   end

--- a/test/export/data/base_test.rb
+++ b/test/export/data/base_test.rb
@@ -1,0 +1,53 @@
+# encoding: utf-8
+
+require File.expand_path(File.join(File.dirname(__FILE__) + '/../../test_helper'))
+
+class TestBase < Test::Unit::TestCase
+  test "#paths finds all the language-dependent data files" do
+    expected = [
+      "annotations/af.xml",
+      "annotationsDerived/af.xml",
+      "casing/af.xml",
+      "collation/af.xml",
+      "main/af.xml",
+      "rbnf/af.xml",
+      "subdivisions/af.xml",
+    ].map {|f| File.join(Cldr::Export::Data.dir, f)}
+    assert_equal expected, Cldr::Export::Data::Base.new('af').send(:paths)
+  end
+
+  test "#paths finds all the supplemental data files" do
+    expected_non_transform_files = [
+      "supplemental/attributeValueValidity.xml",
+      "supplemental/characters.xml",
+      "supplemental/coverageLevels.xml",
+      "supplemental/dayPeriods.xml",
+      "supplemental/genderList.xml",
+      "supplemental/languageGroup.xml",
+      "supplemental/languageInfo.xml",
+      "supplemental/likelySubtags.xml",
+      "supplemental/metaZones.xml",
+      "supplemental/numberingSystems.xml",
+      "supplemental/ordinals.xml",
+      "supplemental/pluralRanges.xml",
+      "supplemental/plurals.xml",
+      "supplemental/rgScope.xml",
+      "supplemental/subdivisions.xml",
+      "supplemental/supplementalData.xml",
+      "supplemental/supplementalMetadata.xml",
+      "supplemental/windowsZones.xml",
+      "validity/currency.xml",
+      "validity/language.xml",
+      "validity/region.xml",
+      "validity/script.xml",
+      "validity/subdivision.xml",
+      "validity/unit.xml",
+      "validity/variant.xml",
+    ].map {|f| File.join(Cldr::Export::Data.dir, f)}
+
+    supplemental_data_paths = Cldr::Export::Data::Base.new(nil).send(:paths)
+
+    assert_equal expected_non_transform_files, supplemental_data_paths.reject {|p| p.include?("transforms/")}
+    assert_not_empty supplemental_data_paths.select {|p| p.include?("transforms/")}
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #96.

Some parts (`ldml`, `ldmlBCP47` amd `supplementalData`) of CLDR data require that you merge all the files with the same root element before doing lookups.

Ref: https://www.unicode.org/reports/tr35/tr35.html#XML_Format

That way, CLDR can move data between files, or split files, for purposes of organization without affecting the actual values.

However, `ruby-cldr` was hard-coding the paths where particular data should be read from.
This lead to data being no longer exported when it was moved in the upstream CLDR.

### What approach did you choose and why?

I changed `Cldr::Export::Data::Base#doc` to return a doc that has all of the related XML files merged into one Nokogiri document.

Merging all of these files is expensive, so I use a class variable as a cache. This might not be the absolute ideal way to do things from a patterns perspective, but it saves us from having to do a much more intense refactor. I like it well enough. 🤷

I use `@locale` as a flag for whether or not the data is supplemental or locale dependent. This will not work if we ever want to use this for the other types of data in CLDR (`keyboard`, `platform`, or `ldmlBCP47`). Perhaps a future refactor would pull this out into subclasses of `Base` instead (`Supplemental` and `LanguageDependent`?)? I have this idea that `lib/cldr/export.rb` could be radically simpler if it didn't have to ask `is_shared_component?` and `Transforms` was less of a special snowflake. But that's a much larger refactor than what I'm attempting right now in this PR. Again, good enough for now. 🤷 

### What should reviewers focus on?

What do you think about the changes?

### The impact of these changes

Fixes #96.

### Testing

You could run `thor cldr:export` for `master` and this branch, then run `diff -r` to compare the outputs:

```bash
git checkout master
thor cldr:export --target=./data_from_master

git checkout movermeyer:movermeyer/merge_before_lookup
thor cldr:export --target=./data_from_pr

diff -r data_from_master data_from_pr
```

Which will show 3 classes of diffs:

1. `Only in data_from_master/en-001: rbnf.yml`. See [comment](https://github.com/ruby-i18n/ruby-cldr/pull/98/files#r764171582).
2. The `data/transforms/*` files all change slightly since they no longer have a `@doc` instance variable. This should not be important to any consumer.
3. `Only in data_after: variables.yml`, this is the result of #96 getting fixed.