### PR TITLE
Add a GitHub pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,34 @@
+### What are you trying to accomplish?
+<!--
+Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
+-->
+
+...
+
+### What approach did you choose and why?
+<!--
+There are many ways to solve a problem. How did you approach this problem and why?
+-->
+
+...
+
+### What should reviewers focus on?
+<!--
+Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
+-->
+
+...
+
+### The impact of these changes
+<!--
+Are there any specific impacts from this change that you'd like to call out?
+-->
+
+...
+
+### Testing
+<!--
+Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
+-->
+
+...


### PR DESCRIPTION
### What are you trying to accomplish?

Adding a pull request template, so I don't have to copy-paste this each time.

### What approach did you choose and why?

Following the [instructions](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) in the GitHub docs.

I added the template that I've been using for all my PRs in this repo.
It's based on a template I've used for several years.

### What should reviewers focus on?

🤷 Opinions can be shared after. I'm going to merge this for now.

### The impact of these changes

If someone opens a PR, their PR description will be populated by the contents of this template by default.