### PR TITLE
Add CLDR `version` parameter to `cldr:download`

### DIFF
--- a/lib/cldr/download.rb
+++ b/lib/cldr/download.rb
@@ -4,8 +4,9 @@ require 'zip'
 
 module Cldr
   class << self
-    def download(source = nil, target = nil)
-      source ||= 'http://unicode.org/Public/cldr/34/core.zip'
+    def download(source = nil, target = nil, version = nil)
+      version ||= 34
+      source ||= "http://unicode.org/Public/cldr/#{version}/core.zip"
       target ||= File.expand_path('./vendor/cldr')
 
       URI.parse(source).open do |tempfile|

--- a/lib/cldr/thor.rb
+++ b/lib/cldr/thor.rb
@@ -5,14 +5,20 @@ module Cldr
   class Thor < ::Thor
     namespace 'cldr'
 
-    desc "download [--source=http://unicode.org/Public/cldr/26/core.zip] [--target=./vendor]",
-         "Download and extract CLDR data from source to target dir"
+    desc "download [--version=34] [--target=./vendor] [--source=http://unicode.org/Public/cldr/34/core.zip]",
+        <<~DESCRIPTION
+          Download and extract CLDR data:
+            * Use the --version parameter to set the release version of the CLDR data to use
+            * Use the --target parameter to specify where on the filesystem to extract the downloaded data
+            * Use the --source parameter to override the location of the CLDR zip to download. Overrides --version
+        DESCRIPTION
     method_options %w(source -s) => :string,
-                   %w(target -t) => :string
+                   %w(target -t) => :string,
+                   %w(version -v) => :string
 
     def download
       require 'cldr/download'
-      Cldr.download(options['source'], options['target'])
+      Cldr.download(options['source'], options['target'], options['version'])
     end
 
     desc "export [--locales=de fr en] [--components=numbers plurals] [--target=./data] [--merge]",


### PR DESCRIPTION
### What are you trying to accomplish?

I want to be able to run the CI against multiple versions of CLDR.
That requires that I'm able to pass in a version number into `cldr:download`

### What approach did you choose and why?

Technically, I could already do this by modifying the `--source` parameter.
However, I thought that was a little ugly, since as a user, I shouldn't need to know/remember where the CLDR release zip is hosted.

I added a new parameter, which is simply the CLDR release version number e.g., `40`.
I also expanded the documentation of the parameters.

### What should reviewers focus on?

IMO, minor concern: This parameter is named `--version`/`-v`, which is conventionally reserved for the script's version (which doesn't exist in this case). Perhaps a different name could be used? I couldn't come up with a nicer one. 🤷

`thor cldr:download --version` fails today:

```
thor cldr:download --version
ERROR: "thor download" was called with arguments ["--version"]
Usage: "thor cldr:download [--source=http://unicode.org/Public/cldr/34/core.zip][--target=./vendor]"
```

With this PR, `thor cldr:download --version` runs with the default value (`34`).

### The impact of these changes

A slightly nicer way of specifying the version to use.

In the future, if CLDR were to change the location of the release data, `ruby-cldr` could change the location, without scripts using `thor:cldr` having to also change their `--source` param.

### Testing


```
thor cldr:download -v 37
```