### PR TITLE
Drop support for EOL'd Rubies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7]
+        ruby-version: [2.6, 2.7]
         cldr-version: [34]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This library is a first stab at that goal. You can:
 
 ## Requirements
 
-  * Ruby 1.9 (if you want well-ordered Hashes to be exported)
+  * Ruby 2.6+
   * Thor
 
 ## Installation


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #99 
Fixes #50

Drop support for [EOL'd versions of Ruby](https://www.ruby-lang.org/en/downloads/branches/) (< 2.6).

### What approach did you choose and why?

Remove those versions from the CI, and change the README.
I then added `required_ruby_version = ">= 2.6.0"` to the gemspec in order to provide machine-readable metadata.

### What should reviewers focus on?

🤷 

Modern (i.e., security-maintained) Nokogiri requires `2.5+`, so we probably cannot reasonably support anything `< 2.5.0`.

### The impact of these changes

The next version of `ruby-cldr` will require 2.6 as a minimum Ruby version.

I couldn't find per-ruby-version download stats for `ruby-cldr` specifically, but according to [this graph](https://stats.rubygems.org/), EOL'd + Unknown Ruby versions account for ~10% of gem downloads.