### PR TITLE
`thor` fixups and component/locale standardization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Changed the keys and values of `ParentLocales` component to be symbols, [#101](https://github.com/ruby-i18n/ruby-cldr/pull/101)
 - Fixed bug with fallbacks for locales that had more than two segments, [#101](https://github.com/ruby-i18n/ruby-cldr/pull/101)
 - Merge all the related data files before doing lookups, [#98](https://github.com/ruby-i18n/ruby-cldr/pull/98)
+- Standardize component names for the `thor cldr:export` command (and internally in the codebase), [#121](https://github.com/ruby-i18n/ruby-cldr/pull/121)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed bug with fallbacks for locales that had more than two segments, [#101](https://github.com/ruby-i18n/ruby-cldr/pull/101)
 - Merge all the related data files before doing lookups, [#98](https://github.com/ruby-i18n/ruby-cldr/pull/98)
 - Standardize component names for the `thor cldr:export` command (and internally in the codebase), [#121](https://github.com/ruby-i18n/ruby-cldr/pull/121)
+- Standardize locale names for the `thor cldr:export` command (and internally in the codebase), [#121](https://github.com/ruby-i18n/ruby-cldr/pull/121)
+- Output `plurals.rb` with the `ruby-cldr` style locale codes (only affects `pt-PT` in CLDR v34), [#121](https://github.com/ruby-i18n/ruby-cldr/pull/121)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ thor cldr:export
 You can also optionally specify locales and/or components to export as well as the target directory:
 
 ```
-thor cldr:export --locales de fr en --components numbers plurals --target=./tmp/export
+thor cldr:export --locales de fr en --components Numbers Plurals --target=./tmp/export
 ```
 
-This will export the components :numbers and :plurals from the locales `de`, `fr` and `en` to the same target directory.
+This will export the components `Numbers` and `Plurals` from the locales `de`, `fr` and `en` to the same target directory.
 
 Also note that CLDR natively builds on a locale fallback concept where all locales eventually fall back to a `root` locale. E.g., the `de-AT` locale only contains a single format for numbers, which means that an application is supposed to use other formats from the `de` locale (fallback). Particular bits of information are only present in the `root` locale where all locales fall back to eventually.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ thor cldr:export
 You can also optionally specify locales and/or components to export as well as the target directory:
 
 ```
-thor cldr:export --locales de fr en --components Numbers Plurals --target=./tmp/export
+thor cldr:export --locales de fr-FR en-ZA --components Numbers Plurals --target=./tmp/export
 ```
 
 This will export the components `Numbers` and `Plurals` from the locales `de`, `fr` and `en` to the same target directory.

--- a/lib/cldr/download.rb
+++ b/lib/cldr/download.rb
@@ -5,20 +5,25 @@ require "open-uri"
 require "zip"
 
 module Cldr
-  class << self
-    def download(source = nil, target = nil, version = nil)
-      version ||= 34
-      source ||= "http://unicode.org/Public/cldr/#{version}/core.zip"
-      target ||= File.expand_path("./vendor/cldr")
+  module Download
+    DEFAULT_SOURCE = "http://unicode.org/Public/cldr/%{version}/core.zip"
+    DEFAULT_TARGET = "./vendor/cldr"
+    DEFAULT_VERSION = 34
 
-      URI.parse(source).open do |tempfile|
-        FileUtils.mkdir_p(target)
-        Zip.on_exists_proc = true
-        Zip::File.open(tempfile.path) do |file|
-          file.each do |entry|
-            path = target + "/" + entry.name
-            FileUtils.mkdir_p(File.dirname(path))
-            file.extract(entry, path)
+    class << self
+      def download(source = DEFAULT_SOURCE, target = DEFAULT_TARGET, version = DEFAULT_VERSION)
+        source = format(source, version: version)
+        target ||= File.expand_path(DEFAULT_TARGET)
+
+        URI.parse(source).open do |tempfile|
+          FileUtils.mkdir_p(target)
+          Zip.on_exists_proc = true
+          Zip::File.open(tempfile.path) do |file|
+            file.each do |entry|
+              path = target + "/" + entry.name
+              FileUtils.mkdir_p(File.dirname(path))
+              file.extract(entry, path)
+            end
           end
         end
       end

--- a/lib/cldr/export.rb
+++ b/lib/cldr/export.rb
@@ -129,8 +129,6 @@ module Cldr
       end
 
       def locales(locale, component, options)
-        locale = to_i18n(locale)
-
         locales = if options[:merge]
           Cldr.fallbacks[locale]
         else
@@ -149,7 +147,7 @@ module Cldr
 
       def path(locale, component, extension)
         path = [Export.base_path]
-        path << locale.to_s.gsub("_", "-") unless shared_component?(component)
+        path << locale.to_s unless shared_component?(component)
         path << "#{component.to_s.underscore}.#{extension}"
         File.join(*path)
       end

--- a/lib/cldr/export.rb
+++ b/lib/cldr/export.rb
@@ -19,13 +19,15 @@ module Cldr
 
     SHARED_COMPONENTS = ["Aliases", "CountryCodes", "CurrencyDigitsAndRounding", "LikelySubtags", "Metazones", "NumberingSystems", "ParentLocales", "RbnfRoot", "RegionCurrencies", "SegmentsRoot", "TerritoriesContainment", "Transforms", "Variables", "WindowsZones"]
 
+    DEFAULT_TARGET = "./data"
+
     class << self
       def base_path
-        @@base_path ||= File.expand_path("./data")
+        @@base_path ||= File.expand_path(DEFAULT_TARGET)
       end
 
       def base_path=(base_path)
-        @@base_path = base_path
+        @@base_path = File.expand_path(base_path)
       end
 
       def export(options = {}, &block)

--- a/lib/cldr/export/data.rb
+++ b/lib/cldr/export/data.rb
@@ -45,7 +45,7 @@ module Cldr
         attr_writer :dir
 
         def locales
-          Dir["#{dir}/main/*.xml"].map { |path| path =~ /([\w_-]+)\.xml/ && Regexp.last_match(1) }
+          Dir["#{dir}/main/*.xml"].map { |path| path =~ /([\w_-]+)\.xml/ && Regexp.last_match(1) }.map { |l| Cldr::Export.to_i18n(l) }.sort
         end
 
         def components

--- a/lib/cldr/export/yaml.rb
+++ b/lib/cldr/export/yaml.rb
@@ -23,7 +23,7 @@ module Cldr
         unless data.empty?
           data = data.deep_stringify_keys if data.respond_to?(:deep_stringify_keys)
           data = data.deep_sort if data.respond_to?(:deep_sort)
-          data = { Cldr::Export.to_i18n(locale).to_s => data } if locale != ""
+          data = { locale.to_s => data } if locale != ""
         end
         data
       end

--- a/lib/cldr/thor.rb
+++ b/lib/cldr/thor.rb
@@ -2,34 +2,35 @@
 
 require "thor"
 require "cldr"
+require "cldr/download"
 
 module Cldr
   class Thor < ::Thor
     namespace "cldr"
 
-    desc "download [--version=34] [--target=./vendor] [--source=http://unicode.org/Public/cldr/34/core.zip]",
-      <<~DESCRIPTION
-        Download and extract CLDR data:
-          * Use the --version parameter to set the release version of the CLDR data to use
-          * Use the --target parameter to specify where on the filesystem to extract the downloaded data
-          * Use the --source parameter to override the location of the CLDR zip to download. Overrides --version
-      DESCRIPTION
-    method_options ["source", "-s"] => :string,
-      ["target", "-t"] => :string,
-      ["version", "-v"] => :string
-
+    desc "download [--version=#{Cldr::Download::DEFAULT_VERSION}] [--target=#{Cldr::Download::DEFAULT_TARGET}] [--source=#{format(Cldr::Download::DEFAULT_SOURCE, version: Cldr::Download::DEFAULT_VERSION)}]", "Download and extract CLDR data"
+    option :version, aliases: [:v], type: :numeric,
+      default: Cldr::Download::DEFAULT_VERSION,
+      banner: Cldr::Download::DEFAULT_VERSION,
+      desc: "Release version of the CLDR data to use"
+    option :target, aliases: [:t], type: :string,
+      default: Cldr::Download::DEFAULT_TARGET,
+      banner: Cldr::Download::DEFAULT_TARGET,
+      desc: "Where on the filesystem to extract the downloaded data"
+    option :source, aliases: [:s], type: :string,
+      default: Cldr::Download::DEFAULT_SOURCE,
+      banner: Cldr::Download::DEFAULT_SOURCE,
+      desc: "Override the location of the CLDR zip to download. Overrides --version"
     def download
-      require "cldr/download"
-      Cldr.download(options["source"], options["target"], options["version"])
+      Cldr::Download.download(options["source"], options["target"], options["version"])
     end
 
-    desc "export [--locales=de fr en] [--components=numbers plurals] [--target=./data] [--merge]",
+    desc "export [--locales=de fr en] [--components=numbers plurals] [--target=#{Cldr::Export::DEFAULT_TARGET}] [--merge/--no-merge]",
       "Export CLDR data by locales and components to target dir"
-    method_options ["locales", "-l"] => :array,
-      ["components", "-l"] => :array,
-      ["target", "-t"] => :string,
-      ["merge", "-m"] => :boolean
-
+    option :locales, aliases: [:l], type: :array, banner: "de fr en"
+    option :components, aliases: [:c], type: :array, banner: "numbers plurals"
+    option :target, aliases: [:t], type: :string, default: Cldr::Export::DEFAULT_TARGET, banner: Cldr::Export::DEFAULT_TARGET
+    option :merge, aliases: [:m], type: :boolean, default: false
     def export
       $stdout.sync
       Cldr::Export.export(options.dup.symbolize_keys) { putc(".") }

--- a/lib/cldr/thor.rb
+++ b/lib/cldr/thor.rb
@@ -25,9 +25,9 @@ module Cldr
       Cldr::Download.download(options["source"], options["target"], options["version"])
     end
 
-    desc "export [--locales=de fr en] [--components=Numbers Plurals] [--target=#{Cldr::Export::DEFAULT_TARGET}] [--merge/--no-merge]",
+    desc "export [--locales=de fr-FR en-ZA] [--components=Numbers Plurals] [--target=#{Cldr::Export::DEFAULT_TARGET}] [--merge/--no-merge]",
       "Export CLDR data by locales and components to target dir"
-    option :locales, aliases: [:l], type: :array, banner: "de fr en"
+    option :locales, aliases: [:l], type: :array, banner: "de fr-FR en-ZA", enum: Cldr::Export::Data.locales
     option :components, aliases: [:c], type: :array, banner: "Numbers Plurals", enum: Cldr::Export::Data.components
     option :target, aliases: [:t], type: :string, default: Cldr::Export::DEFAULT_TARGET, banner: Cldr::Export::DEFAULT_TARGET
     option :merge, aliases: [:m], type: :boolean, default: false
@@ -38,6 +38,11 @@ module Cldr
 
       # We do this validation, since thor doesn't
       # https://github.com/rails/thor/issues/783
+      if formatted_options.key?(:locales)
+        formatted_options[:locales] = formatted_options[:locales].map(&:to_sym) if formatted_options.key?(:locales)
+        unknown_locales = formatted_options[:locales] - Cldr::Export::Data.locales
+        raise ArgumentError, "Unknown locales: #{unknown_locales.map { |l| "`#{l}`" }.join(", ")}" unless unknown_locales.empty?
+      end
       if formatted_options.key?(:components)
         formatted_options[:components] = formatted_options[:components].map(&:to_sym) if formatted_options.key?(:components)
         unknown_components = formatted_options[:components] - Cldr::Export::Data.components

--- a/test/export/data/base_test.rb
+++ b/test/export/data/base_test.rb
@@ -14,7 +14,7 @@ class TestBase < Test::Unit::TestCase
       "rbnf/af.xml",
       "subdivisions/af.xml",
     ].map { |f| File.join(Cldr::Export::Data.dir, f) }
-    assert_equal expected, Cldr::Export::Data::Base.new("af").send(:paths)
+    assert_equal expected, Cldr::Export::Data::Base.new(:af).send(:paths)
   end
 
   test "#paths finds all the supplemental data files" do

--- a/test/export/data/calendars_test.rb
+++ b/test/export/data/calendars_test.rb
@@ -6,7 +6,7 @@ require File.expand_path(File.join(File.dirname(__FILE__) + "/../../test_helper"
 class TestCldrDataCalendars < Test::Unit::TestCase
   def gregorian(options = {})
     locale = options[:locale] || :de
-    Cldr::Export.data(:calendars, locale, options)[:calendars][:gregorian]
+    Cldr::Export.data(:Calendars, locale, options)[:calendars][:gregorian]
   end
 
   test "calendars months :de" do

--- a/test/export/data/currencies_test.rb
+++ b/test/export/data/currencies_test.rb
@@ -34,14 +34,14 @@ class TestCldrCurrencies < Test::Unit::TestCase
              :KRH, :KRO, :MCF, :MDC, :MKN, :MVP, :UYI, :VNN, :XSU, :XUA, :YUR,
              :BYN, :CNH, :MRU, :STN, :VES,]
 
-    currencies = Cldr::Export::Data::Currencies.new("de")[:currencies]
+    currencies = Cldr::Export::Data::Currencies.new(:de)[:currencies]
     assert_empty codes - currencies.keys, "Unexpected missing currencies"
     assert_empty currencies.keys - codes, "Unexpected extra currencies"
     assert_equal({ name: "Euro", "narrow_symbol": "€", one: "Euro", other: "Euro", symbol: "€" }, currencies[:EUR])
   end
 
   test "currencies populates symbol-narrow when narrow symbol is not equal to the regular symbol" do
-    currencies = Cldr::Export::Data::Currencies.new("root")[:currencies]
+    currencies = Cldr::Export::Data::Currencies.new(:root)[:currencies]
     assert_equal({ symbol: "US$", "narrow_symbol": "$" }, currencies[:USD])
   end
 

--- a/test/export/data/delimiters_test.rb
+++ b/test/export/data/delimiters_test.rb
@@ -19,7 +19,7 @@ class TestCldrDataDelimiters < Test::Unit::TestCase
         },
       },
     }
-    assert_equal expected, Cldr::Export::Data::Delimiters.new("de")
+    assert_equal expected, Cldr::Export::Data::Delimiters.new(:de)
   end
 
   # Cldr::Export::Data.locales.each do |locale|

--- a/test/export/data/languages_test.rb
+++ b/test/export/data/languages_test.rb
@@ -66,7 +66,7 @@ class TestCldrDataLanguages < Test::Unit::TestCase
              :ybb, :yi, :yo, :yrl, :yue, :za, :zap, :zbl, :zea, :zen,
              :zgh, :zh, :"zh-Hans", :"zh-Hant", :zu, :zun, :zxx, :zza,]
 
-    languages = Cldr::Export::Data::Languages.new("de")[:languages]
+    languages = Cldr::Export::Data::Languages.new(:de)[:languages]
 
     assert_empty codes - languages.keys, "Unexpected missing languages"
     assert_empty languages.keys - codes, "Unexpected extra languages"

--- a/test/export/data/numbers_test.rb
+++ b/test/export/data/numbers_test.rb
@@ -19,7 +19,7 @@ class TestCldrDataNumbers < Test::Unit::TestCase
       superscripting_exponent: "·",
       time_separator: ":",
     }
-    assert_equal expected, Cldr::Export::Data::Numbers.new("de")[:numbers][:symbols]
+    assert_equal expected, Cldr::Export::Data::Numbers.new(:de)[:numbers][:symbols]
   end
 
   test "number formats :de" do
@@ -82,12 +82,12 @@ class TestCldrDataNumbers < Test::Unit::TestCase
       percent: { number_system: "latn", patterns: { default: "#,##0 %" } },
       scientific: { number_system: "latn", patterns: { default: "#E0" } },
     }
-    assert_equal expected, Cldr::Export::Data::Numbers.new("de")[:numbers][:formats]
+    assert_equal expected, Cldr::Export::Data::Numbers.new(:de)[:numbers][:formats]
   end
 
   test "redirects in root locale" do
     assert_equal :"numbers.formats.decimal.patterns.short",
-      Cldr::Export::Data::Numbers.new("root")[:numbers][:formats][:decimal][:patterns]["long"]
+      Cldr::Export::Data::Numbers.new(:root)[:numbers][:formats][:decimal][:patterns]["long"]
   end
 
   # Cldr::Export::Data.locales.each do |locale|

--- a/test/export/data/parent_locales_test.rb
+++ b/test/export/data/parent_locales_test.rb
@@ -7,12 +7,12 @@ require File.expand_path(File.join(File.dirname(__FILE__) + "/../../test_helper"
 
 class TestParentLocales < Test::Unit::TestCase
   test "ParentLocales uses symbols for keys and values" do
-    data = Cldr::Export.data("ParentLocales", {})
+    data = Cldr::Export.data(:ParentLocales, {})
     assert data.all? { |key, value| key.is_a?(Symbol) && value.is_a?(Symbol) }, "Not all keys and values are Symbols"
   end
 
   test "ParentLocales#to_h uses strings for keys and values" do
-    data = Cldr::Export.data("ParentLocales", {}).to_h
+    data = Cldr::Export.data(:ParentLocales, {}).to_h
     assert data.all? { |key, value| key.is_a?(String) && value.is_a?(String) }, "Not all keys and values are Strings"
   end
 end

--- a/test/export/data/units_test.rb
+++ b/test/export/data/units_test.rb
@@ -14,7 +14,7 @@ class TestCldrDataUnits < Test::Unit::TestCase
       minute: { one: "{0} Minute",  other: "{0} Minuten" },
       second: { one: "{0} Sekunde", other: "{0} Sekunden" },
     }
-    data = Cldr::Export::Data::Units.new("de")[:units][:unitLength][:long]
+    data = Cldr::Export::Data::Units.new(:de)[:units][:unitLength][:long]
 
     assert_operator data.keys.count, :>=, 46
     assert_equal units[:day],    data[:"duration-day"]

--- a/test/export/yaml_test.rb
+++ b/test/export/yaml_test.rb
@@ -5,7 +5,7 @@ require File.expand_path(File.join(File.dirname(__FILE__) + "/../test_helper"))
 
 class TestYaml < Test::Unit::TestCase
   test "Hash values are deep sorted" do
-    data = Cldr::Export::Yaml.new.export("fr", :Currencies, merge: true)
+    data = Cldr::Export::Yaml.new.export(:fr, :Currencies, merge: true)
     assert_equal deep_flatten(data.deep_sort).to_a, deep_flatten(data).to_a
   end
 

--- a/test/export/yaml_test.rb
+++ b/test/export/yaml_test.rb
@@ -5,7 +5,7 @@ require File.expand_path(File.join(File.dirname(__FILE__) + "/../test_helper"))
 
 class TestYaml < Test::Unit::TestCase
   test "Hash values are deep sorted" do
-    data = Cldr::Export::Yaml.new.export("fr", "currencies", merge: true)
+    data = Cldr::Export::Yaml.new.export("fr", :Currencies, merge: true)
     assert_equal deep_flatten(data.deep_sort).to_a, deep_flatten(data).to_a
   end
 

--- a/test/export_test.rb
+++ b/test/export_test.rb
@@ -25,33 +25,33 @@ class TestExport < Test::Unit::TestCase
   end
 
   test "passing the merge option generates and merge data for all fallback locales" do
-    data = Cldr::Export.data(:Numbers, "de-AT")
+    data = Cldr::Export.data(:Numbers, :"de-AT")
     assert !data[:numbers][:formats][:nan]
 
-    data = Cldr::Export.data(:Numbers, "de-AT", merge: true)
+    data = Cldr::Export.data(:Numbers, :"de-AT", merge: true)
     assert_equal "NaN", data[:numbers][:symbols][:nan]
   end
 
   test "passing the merge option generates and merges Plurals data from fallback locales" do
-    data = Cldr::Export.data(:Plurals, "af-NA")
+    data = Cldr::Export.data(:Plurals, :"af-NA")
     assert_equal "", data
 
-    data = Cldr::Export.data(:Plurals, "af-NA", merge: true)
+    data = Cldr::Export.data(:Plurals, :"af-NA", merge: true)
     assert_match(/{ :'af-NA' => { :i18n => { :plural/, data)
   end
 
   test "the merge option respects parentLocales" do
-    data = Cldr::Export.data(:Calendars, "en-GB", merge: true)
+    data = Cldr::Export.data(:Calendars, :"en-GB", merge: true)
     assert_equal "dd/MM/y", data[:calendars][:gregorian][:additional_formats]["yMd"]
   end
 
   test "exports data to files" do
-    Cldr::Export.export(locales: ["de"], components: [:Calendars])
+    Cldr::Export.export(locales: [:de], components: [:Calendars])
     assert File.exist?(Cldr::Export.path("de", "calendars", "yml"))
   end
 
   test "exported data starts with the locale at top level" do
-    Cldr::Export.export(locales: ["de"], components: [:Calendars])
+    Cldr::Export.export(locales: [:de], components: [:Calendars])
     data = {}
     File.open(Cldr::Export.path("de", "calendars", "yml")) do |f|
       data = YAML.load(f)
@@ -60,13 +60,13 @@ class TestExport < Test::Unit::TestCase
   end
 
   test "#locales does not fall back to English (unless the locale is English based)" do
-    assert_equal [:ko, :root], Cldr::Export.locales("ko", "numbers", merge: true)
-    assert_equal [:"pt-BR", :pt, :root], Cldr::Export.locales("pt_BR", "numbers", merge: true)
-    assert_equal [:"en-GB", :"en-001", :en, :root], Cldr::Export.locales("en_GB", "numbers", merge: true)
+    assert_equal [:ko, :root], Cldr::Export.locales(:ko, "numbers", merge: true)
+    assert_equal [:"pt-BR", :pt, :root], Cldr::Export.locales(:"pt-BR", "numbers", merge: true)
+    assert_equal [:"en-GB", :"en-001", :en, :root], Cldr::Export.locales(:"en-GB", "numbers", merge: true)
   end
 
   test "#locales does not fall back if :merge option is false" do
-    assert_equal [:"pt-BR"], Cldr::Export.locales("pt_BR", "numbers", merge: false)
+    assert_equal [:"pt-BR"], Cldr::Export.locales(:"pt-BR", "numbers", merge: false)
   end
 
   # Cldr::Export::Data.locales.each do |locale|

--- a/test/export_test.rb
+++ b/test/export_test.rb
@@ -25,33 +25,33 @@ class TestExport < Test::Unit::TestCase
   end
 
   test "passing the merge option generates and merge data for all fallback locales" do
-    data = Cldr::Export.data("numbers", "de-AT")
+    data = Cldr::Export.data(:Numbers, "de-AT")
     assert !data[:numbers][:formats][:nan]
 
-    data = Cldr::Export.data("numbers", "de-AT", merge: true)
+    data = Cldr::Export.data(:Numbers, "de-AT", merge: true)
     assert_equal "NaN", data[:numbers][:symbols][:nan]
   end
 
   test "passing the merge option generates and merges Plurals data from fallback locales" do
-    data = Cldr::Export.data("Plurals", "af-NA")
+    data = Cldr::Export.data(:Plurals, "af-NA")
     assert_equal "", data
 
-    data = Cldr::Export.data("Plurals", "af-NA", merge: true)
+    data = Cldr::Export.data(:Plurals, "af-NA", merge: true)
     assert_match(/{ :'af-NA' => { :i18n => { :plural/, data)
   end
 
   test "the merge option respects parentLocales" do
-    data = Cldr::Export.data("calendars", "en-GB", merge: true)
+    data = Cldr::Export.data(:Calendars, "en-GB", merge: true)
     assert_equal "dd/MM/y", data[:calendars][:gregorian][:additional_formats]["yMd"]
   end
 
   test "exports data to files" do
-    Cldr::Export.export(locales: ["de"], components: ["calendars"])
+    Cldr::Export.export(locales: ["de"], components: [:Calendars])
     assert File.exist?(Cldr::Export.path("de", "calendars", "yml"))
   end
 
   test "exported data starts with the locale at top level" do
-    Cldr::Export.export(locales: ["de"], components: ["calendars"])
+    Cldr::Export.export(locales: ["de"], components: [:Calendars])
     data = {}
     File.open(Cldr::Export.path("de", "calendars", "yml")) do |f|
       data = YAML.load(f)


### PR DESCRIPTION
### What are you trying to accomplish?

`thor` has changed the way that you specify options. I've refreshed our use of `thor` to match.
As part of this, I standardize the names used to refer to components and locales on the command line (and internally in the codebase).

### What approach did you choose and why?

I arbitrarily picked the capital-case of the module names.
Before, you could specify `CountryCodes`, `country-codes`, or `country_codes` and all would work. There was no need to support this flexibility, so I picked one style to enforce. Now, only `CountryCodes` is valid.

I also arbitrarily picked the `ruby-i18n` version of locales codes (`en-US` instead of `en_US`)
Before, it was expecting CLDR versions of locale codes (e.g., `en_US`).
Standardizing on this format allowed me to remove some unnecessary calls to `to_i18n`.

Since [`type: array` values don't yet get `enum` validation from `thor`](https://github.com/rails/thor/issues/783), this validation of the inputs had to be done in `ruby-cldr`. 

### What should reviewers focus on?

🤷

There is only one change to the output of `thor cldr:export`, which was incorrectly outputting the wrong locale code:

```diff
diff -r before/pt-PT/plurals.rb after/pt-PT/plurals.rb
1c1
< { :'pt_PT' => { :i18n => { :plural => { :keys => [:one, :other], :rule => lambda { |n| n = n.respond_to?(:abs) ? n.abs : ((m = n.to_s)[0] == "-" ? m[1,m.length] : m); (n.to_i == 1 && ((v = n.to_s.split(".")[1]) ? v.length : 0) == 0) ? :one : :other } } } } }
\ No newline at end of file
---
> { :'pt-PT' => { :i18n => { :plural => { :keys => [:one, :other], :rule => lambda { |n| n = n.respond_to?(:abs) ? n.abs : ((m = n.to_s)[0] == "-" ? m[1,m.length] : m); (n.to_i == 1 && ((v = n.to_s.split(".")[1]) ? v.length : 0) == 0) ? :one : :other } } } } }
\ No newline at end of file
```

### The impact of these changes

* Users will have to specify the capital-case versions of the component names when they use `thor cldr:export`. 
* Users will have to specify the `ruby-cldr` version of the locale codes when they use `thor cldr:export`. 
* When users use `thor help cldr:export`, the printout is much nicer, and relies on defaults that come from the constants actually used by the code.

### Testing

`thor cldr:export`

See the new help docs with:

```
thor help cldr:download
thor help cldr:export
```