### PR TITLE
Use Nokogiri for all XML parsing

### DIFF
--- a/lib/cldr/export/data/plurals/rules.rb
+++ b/lib/cldr/export/data/plurals/rules.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
 
 require "rubygems"
-require "rexml/document"
+require "nokogiri"
 
 module Cldr
   module Export
@@ -10,10 +10,12 @@ module Cldr
         class Rules < Array
           class << self
             def parse(xml)
+              doc = Nokogiri.XML(xml)
+
               rules = new
-              REXML::Document.new(xml).elements.each("//pluralRules") do |tag|
-                rule = Rule.new(tag.attributes["locales"].split(/\s+/))
-                tag.elements.each("pluralRule") { |tag| rule << [tag.attributes["count"], tag.text] }
+              doc.xpath("//pluralRules").each do |node|
+                rule = Rule.new(node.attribute("locales").value.split(/\s+/))
+                node.xpath("pluralRule").each { |child| rule << [child.attribute("count").value, child.text] }
                 rules << rule
               end
               rules


### PR DESCRIPTION
### What are you trying to accomplish?

I noticed that we were using `rexml` for XML parsing in `lib/cldr/export/data/plurals/rules.rb`, but Nokogiri everywhere else. 

This PR removes that discrepancy, using Nokogiri everywhere.

### What approach did you choose and why?

Rewrote the snippet of code using Nokogiri syntax.

### What should reviewers focus on?

🤷 

The return value of `Cldr::Export::Data::Plurals::Rules#parse` is unchanged.
The output of `thor cldr:export` is unchanged.

### The impact of these changes

Nothing outwardly visible. Just a single way of parsing XML, instead of two.

### Testing

```
thor cldr:export --components=Plurals
```
