### PR TITLE
Drop Ruby 2.6 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [2.6, 2.7, 3.0, 3.1]
+        ruby-version: [2.7, 3.0, 3.1]
         cldr-version: [34]
 
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ inherit_gem:
   rubocop-shopify: rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   UseCache: true
   CacheRootDirectory: tmp/rubocop
   NewCops: enable

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ CLDR (["Common Locale Data Repository"](https://cldr.unicode.org/)) contains ton
 
 For localizing applications in Ruby we'll obviously be able to use this incredibly comprehensive and well-maintained resource.
 
-This library is a first stab at that goal. You can: 
+This library is a first stab at that goal. You can:
 
-* export CLDR data to YAML and Ruby formatted files which are supposed to be usable in an [`I18n`](https://github.com/ruby-i18n/i18n) context but might be usable elsewhere, too. 
+* export CLDR data to YAML and Ruby formatted files which are supposed to be usable in an [`I18n`](https://github.com/ruby-i18n/i18n) context but might be usable elsewhere, too.
 * use CLDR compliant formatters for the following types: number, percentage, currency, date, time, datetime.
 
 ## Requirements
 
-  * Ruby 2.6+
+  * Ruby 2.7+
   * Thor
 
 ## Installation
@@ -83,7 +83,7 @@ format(:de, 123456.78)
 format(:de, 123456.78, :as => :percent)
 # => "123.457 %"
 
-format(:de, 123456.78, :currency => 'EUR') 
+format(:de, 123456.78, :currency => 'EUR')
 # => "123.456,78 EUR"
 
 format(:de, Date.new(2010, 1, 1), :format => :full)

--- a/lib/cldr/export.rb
+++ b/lib/cldr/export.rb
@@ -159,6 +159,7 @@ module Cldr
       def should_merge_root?(locale, component, options)
         return false if [:Rbnf, :Fields].include?(component)
         return true if options[:merge]
+
         locale == :en
       end
     end

--- a/lib/cldr/export/data/aliases.rb
+++ b/lib/cldr/export/data/aliases.rb
@@ -23,6 +23,7 @@ module Cldr
         def alias_for(alias_tag)
           doc.xpath("//alias/#{alias_tag}").each_with_object({}) do |alias_data, ret|
             next unless (replacement_attr = alias_data.attribute("replacement"))
+
             replacement = replacement_attr.value
 
             if replacement.include?(" ")

--- a/lib/cldr/export/data/calendars/gregorian.rb
+++ b/lib/cldr/export/data/calendars/gregorian.rb
@@ -91,6 +91,7 @@ module Cldr
                 key  = name.gsub("era", "").gsub(/s$/, "").downcase.to_sym
                 key_result = select(path).each_with_object({}) do |node, ret|
                   next ret if node.name == "alias" # TODO: Actually handle alias nodes, https://github.com/ruby-i18n/ruby-cldr/issues/78
+
                   type = node.attribute("type").value.to_i
                   ret[type] = node.content
                 end

--- a/lib/cldr/export/data/country_codes.rb
+++ b/lib/cldr/export/data/country_codes.rb
@@ -14,6 +14,7 @@ module Cldr
         def country_codes
           doc.xpath("//codeMappings/*").each_with_object({}) do |node, hash|
             next unless node.name == "territoryCodes"
+
             type = node.attribute("type").to_s.to_sym
             hash[type] = {}
             hash[type]["numeric"] = node[:numeric] if node[:numeric]

--- a/lib/cldr/export/data/numbers.rb
+++ b/lib/cldr/export/data/numbers.rb
@@ -61,6 +61,7 @@ module Cldr
                   pattern_count_node = pattern_node.attribute("count")
 
                   next if draft?(pattern_node)
+
                   pattern_key = pattern_key_node ? pattern_key_node.value : :default
 
                   if pattern_count_node

--- a/lib/cldr/export/data/plurals/rules.rb
+++ b/lib/cldr/export/data/plurals/rules.rb
@@ -153,6 +153,7 @@ module Cldr
           def to_ruby
             @ruby ||= begin
               return nil unless @operator
+
               enclose = false
               fraction = false
               case @type

--- a/lib/cldr/format/decimal/integer.rb
+++ b/lib/cldr/format/decimal/integer.rb
@@ -21,6 +21,7 @@ module Cldr
 
         def format_groups(string)
           return string if groups.empty?
+
           tokens = []
           tokens << chop_group(string, groups.first)
           tokens << chop_group(string, groups.last) while string.length > groups.last
@@ -30,6 +31,7 @@ module Cldr
 
         def parse_groups(format)
           return [] unless (index = format.rindex(","))
+
           rest   = format[0, index]
           widths = [format.length - index - 1]
           widths << rest.length - rest.rindex(",") - 1 if rest.rindex(",")

--- a/lib/cldr/format/time.rb
+++ b/lib/cldr/format/time.rb
@@ -52,6 +52,7 @@ module Cldr
 
       def second_fraction(time, pattern, length)
         raise "can not use the S format with more than 6 digits" if length > 6
+
         (time.usec.to_f / 10**(6 - length)).round.to_s.rjust(length, "0")
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,6 +17,7 @@ module Test
           false
         end
         raise "#{test_name} is already defined in #{self}" if defined
+
         if block_given?
           define_method(test_name, &block)
         else


### PR DESCRIPTION
### What are you trying to accomplish?

Similar to #110. `ruby-cldr` is still pre-1.0.0, so I feel fine dropping support for the [now EOL'd Ruby 2.6](https://www.ruby-lang.org/en/downloads/branches/).

### What approach did you choose and why?

1. Dropped it from the CI
2. Bumped the syntax version for Rubocop
3. Corrected the Rubocop offenses  

### What should reviewers focus on?

🤷

### The impact of these changes

Nothing really. Dropping backwards compatibility while we still can (pre-1.0.0).
Allows us to have less burden going into a 1.0.0.