### PR TITLE
Add the `c` and `e` plural operands

### DIFF
--- a/lib/cldr/export/data/plurals/rules.rb
+++ b/lib/cldr/export/data/plurals/rules.rb
@@ -178,9 +178,11 @@ module Cldr
               when "w"
                 op = '(w = n.to_s.split(".")[1]) ? w.gsub(/0+$/, "").length : 0'
                 enclose = true
-              else
+              when "n"
                 fraction = true
                 op = "n.to_f"
+              else
+                raise StandardError, "Unknown plural operand `#{@type}`"
               end
               if @mod
                 op = "(" << op << ")" if enclose

--- a/lib/cldr/export/data/plurals/rules.rb
+++ b/lib/cldr/export/data/plurals/rules.rb
@@ -178,6 +178,12 @@ module Cldr
               when "w"
                 op = '(w = n.to_s.split(".")[1]) ? w.gsub(/0+$/, "").length : 0'
                 enclose = true
+              when "c", "e"
+                # We don't support numbers in the "compact decimal" format.
+                # Since `c`/`e` are always 0 for non-"compact decimal" format
+                # numbers, we just hardcode it to 0 for now.
+                op = "#{@type} = 0"
+                enclose = true
               when "n"
                 fraction = true
                 op = "n.to_f"

--- a/lib/cldr/export/data/plurals/rules.rb
+++ b/lib/cldr/export/data/plurals/rules.rb
@@ -63,7 +63,7 @@ module Cldr
               code = scrub_code(code)
 
               code = code.split("@").first.to_s
-              operand = /(n|i|f|t|v|w)/i
+              operand = /(n|i|v|w|f|t|c|e)/i # Ordered as they appear in the spec.
               expr = /#{operand}(?:\s+(?:mod|%)\s+([\d]+))?/i
               range = /(?:\d+\.\.\d+|\d+)/i
               range_list = /(#{range}(?:\s*,\s*#{range})*)/i
@@ -142,12 +142,19 @@ module Cldr
           end
 
           # Symbol  Value
-          # n       absolute value of the source number (integer and decimals).
-          # i       integer digits of n.
-          # v       number of visible fraction digits in n, with trailing zeros.
-          # w       number of visible fraction digits in n, without trailing zeros.
-          # f       visible fractional digits in n, with trailing zeros.
-          # t       visible fractional digits in n, without trailing zeros.
+          # n       the absolute value of N.*
+          # i       the integer digits of N.*
+          # v       the number of visible fraction digits in N, _with_ trailing zeros.*
+          # w       the number of visible fraction digits in N, _without_ trailing zeros.*
+          # f       the visible fraction digits in N, _with_ trailing zeros, expressed as an integer.*
+          # t       the visible fraction digits in N, _without_ trailing zeros, expressed as an integer.*
+          # c       compact decimal exponent value: exponent of the power of 10 used in compact decimal formatting.
+          # e       a deprecated synonym for ‘c’. Note: it may be redefined in the future.
+          #
+          # * If there is a compact decimal exponent value (‘c’), then the n, i, f, t, v, and w values are computed
+          # after shifting the decimal point in the original by the ‘c’ value. So for 1.2c3, the n, i, f, t, v,
+          # and w values are the same as those of 1200: i=1200 and f=0. Similarly, 1.2005c3 has i=1200 and
+          # f=5 (corresponding to 1200.5).
           #
           # http://www.unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules
           def to_ruby

--- a/test/export/data/plurals_test.rb
+++ b/test/export/data/plurals_test.rb
@@ -106,6 +106,13 @@ class TestCldrDataPluralParser < Test::Unit::TestCase
     assert_equal([:in, [[], [3..4]], "2", "f"], [rule[1][1].operator, rule[1][1].operand, rule[1][1].mod, rule[1][1].type])
   end
 
+  def test_parse_fails_when_given_unknown_operand
+    exc = assert_raises do
+      Cldr::Export::Data::Plurals::Rule.parse("q = 0")
+    end
+    assert_equal("can not parse 'q = 0'", exc.message)
+  end
+
   def test_compiles_empty
     assert_equal(nil, Cldr::Export::Data::Plurals::Rule.parse("").to_ruby)
     assert_equal(nil, Cldr::Export::Data::Plurals::Rule.parse(" ").to_ruby)

--- a/test/export/data/plurals_test.rb
+++ b/test/export/data/plurals_test.rb
@@ -180,6 +180,10 @@ class TestCldrDataPluralParser < Test::Unit::TestCase
     assert_equal("((n.to_f % 100) != 100 || (((n.to_f % 100) % 1).zero? && (!(10..19).include?(n.to_f % 100) || !(90..99).include?(n.to_f % 100))))", Cldr::Export::Data::Plurals::Rule.parse("n % 100 != 10..19,90..99,100").to_ruby)
   end
 
+  def test_compiles_e_operand_as_always_0
+    assert_equal("((e = 0) == 0 || !(0..5).include?(e = 0))", Cldr::Export::Data::Plurals::Rule.parse("e = 0 or e != 0..5").to_ruby)
+  end
+
   def test_eval_n_in
     n = 3.3
     assert_equal(false, eval(Cldr::Export::Data::Plurals::Rule.parse("n mod 100 in 3..6").to_ruby, binding)) # rubocop:disable Security/Eval
@@ -254,5 +258,18 @@ class TestCldrDataPluralParser < Test::Unit::TestCase
     assert_equal(:other, fn.call(0.11))
     assert_equal(:other, fn.call("0.220"))
     assert_equal(:other, fn.call("41.0"))
+  end
+
+  def test_e_operand
+    # one: i = 0,1 @integer 0, 1 @decimal 0.0~1.5
+    # many: e = 0 and i != 0 and i % 1000000 = 0 and v = 0 or e != 0..5 @integer 1000000, 1c6, 2c6, 3c6, 4c6, 5c6, 6c6, … @decimal 1.0000001c6, 1.1c6, 2.0000001c6, 2.1c6, 3.0000001c6, 3.1c6, …
+    # other: @integer 2~17, 100, 1000, 10000, 100000, 1c3, 2c3, 3c3, 4c3, 5c3, 6c3, … @decimal 2.0~3.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, 1.0001c3, 1.1c3, 2.0001c3, 2.1c3, 3.0001c3, 3.1c3, …
+    fn = eval(cldr_rules.rule(:fr).to_ruby)
+    assert_equal(:one, fn.call(0))
+    assert_equal(:one, fn.call(1))
+    assert_equal(:many, fn.call(1000000))
+    assert_equal(:many, fn.call(2000000))
+    assert_equal(:other, fn.call(1000001))
+    assert_equal(:other, fn.call(1000000.0))
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes https://github.com/ruby-i18n/ruby-cldr/issues/63

Ref: http://unicode.org/reports/tr35/tr35-numbers.html#Operands

### What approach did you choose and why?

This is a reformulation of my [previous PR](https://github.com/movermeyer/ruby-cldr/pull/1) that did this. I've cherry-picked each commit from them and refreshed them somewhat.

#### `#parse`

Added the operands to the regex so that the parser can understand them.

#### `#to_ruby`

`ruby-cldr` doesn't support "compact decimal" format numbers.
To do so would require refactoring the way we compute the `f`, `t`, `v`, and `w` values.

Since `c`/`e` are always 0 for non-"compact decimal" format numbers, we just hardcode it to 0 for now.

Previously, `to_ruby` assumed that any unknown operand was `n`.
I changed the `else` condition to raise, and gave `n` its own `when` case.

### What should reviewers focus on?

🤷 

### Testing

```
bundle exec thor cldr:download
bundle exec ruby test/export/data/plurals_test.rb
bundle exec thor cldr:export
```

### The impact of these changes

Users of `ruby-cldr` will be able to parse CLDR v38+ files again.