### PR TITLE
CLDR v40 CI support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         ruby-version: [2.7, 3.0, 3.1]
-        cldr-version: [39]
+        cldr-version: [40]
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/lib/cldr/download.rb
+++ b/lib/cldr/download.rb
@@ -8,7 +8,7 @@ module Cldr
   module Download
     DEFAULT_SOURCE = "http://unicode.org/Public/cldr/%{version}/core.zip"
     DEFAULT_TARGET = "./vendor/cldr"
-    DEFAULT_VERSION = 39
+    DEFAULT_VERSION = 40
 
     class << self
       def download(source = DEFAULT_SOURCE, target = DEFAULT_TARGET, version = DEFAULT_VERSION)

--- a/test/export/data/languages_test.rb
+++ b/test/export/data/languages_test.rb
@@ -48,7 +48,7 @@ class TestCldrDataLanguages < Test::Unit::TestCase
              :nym, :nyn, :nyo, :nzi, :oc, :oj, :om, :or, :os, :osa, :ota,
              :pa, :pag, :pal, :pam, :pap, :pau, :pcd, :pcm, :pdc, :pdt,
              :peo, :pfl, :phn, :pi, :pl, :pms, :pnt, :pon, :prg, :pro,
-             :ps, :pt, :qu, :quc, :qug, :raj, :rap, :rar, :rgn, :rif, :rm,
+             :ps, :pt, :qu, :quc, :qug, :raj, :rap, :rar, :rgn, :rhg, :rif, :rm,
              :rn, :ro, :"ro-MD", :rof, :rom, :rtm, :ru, :rue, :rug,
              :rup, :rw, :rwk, :sa, :sad, :sah, :sam, :saq, :sas, :sat, :saz,
              :sba, :sbp, :sc, :scn, :sco, :sd, :sdc, :sdh, :se, :see, :seh,


### PR DESCRIPTION
### What are you trying to accomplish?

Bumping the version of CLDR used in CI and adjusting the tests.

### What approach did you choose and why?

Version bump + test adjustments.

### What should reviewers focus on?

This doesn't mean that we have support for CLDR v40. Indeed, there are many known issues with CLDR 38+. However, I'd rather be running the latest versions of CLDR in CI.