### PR TITLE
Move exported locale-specific data into subdirectory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Output `plurals.rb` with the `ruby-cldr` style locale codes (only affects `pt-PT` in CLDR v34), [#121](https://github.com/ruby-i18n/ruby-cldr/pull/121)
 - Export data at with a consistent minimum draft status, [#124](https://github.com/ruby-i18n/ruby-cldr/pull/124)
 - Add `--draft-status` flag for specifying the minimum draft status for data to be exported, [#124](https://github.com/ruby-i18n/ruby-cldr/pull/124)
+- Export locale-specific data files into `locales` subdirectory, [#135](https://github.com/ruby-i18n/ruby-cldr/pull/135)
 
 ---
 

--- a/lib/cldr/export.rb
+++ b/lib/cldr/export.rb
@@ -158,7 +158,10 @@ module Cldr
 
       def path(locale, component, extension)
         path = [Export.base_path]
-        path << locale.to_s unless shared_component?(component)
+        unless shared_component?(component)
+          path << "locales"
+          path << locale.to_s
+        end
         path << "#{component.to_s.underscore}.#{extension}"
         File.join(*path)
       end


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #59. Fixes #94

Users want a way to know which locales are available. Presently, they can iterate over the directory names, but they have to remember/notice to exclude the `transforms` directory. 

### What approach did you choose and why?

Move the locale-specific data into a `locales` subdirectory.

### What should reviewers focus on?

Users will will have to adjust their processing to point at the subdirectory, but no longer need to remember to exclude the `transforms` directory.

### The impact of these changes

Locale-specific data is now under a subdirectory when exported. 

### Testing

```
thor cldr:download
thor cldr:export
ls data/
```

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
