### PR TITLE
Hide `alt` values

### DIFF
--- a/lib/cldr/export/data/base.rb
+++ b/lib/cldr/export/data/base.rb
@@ -27,10 +27,6 @@ module Cldr
 
         protected
 
-        def alt?(node) # TODO: Move this into DataFile
-          !node.attribute("alt").nil?
-        end
-
         def name(node)
           node.name.underscore
         end

--- a/lib/cldr/export/data/languages.rb
+++ b/lib/cldr/export/data/languages.rb
@@ -13,7 +13,7 @@ module Cldr
 
         def languages
           @languages ||= select("localeDisplayNames/languages/language").each_with_object({}) do |node, result|
-            result[Cldr::Export.to_i18n(node.attribute("type").value)] = node.content unless alt?(node)
+            result[Cldr::Export.to_i18n(node.attribute("type").value)] = node.content
           end
         end
       end

--- a/lib/cldr/export/data/subdivisions.rb
+++ b/lib/cldr/export/data/subdivisions.rb
@@ -13,7 +13,7 @@ module Cldr
 
         def subdivisions
           @subdivisions ||= select("localeDisplayNames/subdivisions/subdivision").each_with_object({}) do |node, result|
-            result[node.attribute("type").value.to_sym] = node.content unless alt?(node)
+            result[node.attribute("type").value.to_sym] = node.content
           end
         end
       end

--- a/lib/cldr/export/data/territories.rb
+++ b/lib/cldr/export/data/territories.rb
@@ -13,7 +13,7 @@ module Cldr
 
         def territories
           @territories ||= select("localeDisplayNames/territories/territory").each_with_object({}) do |node, result|
-            result[node.attribute("type").value.to_sym] = node.content unless alt?(node)
+            result[node.attribute("type").value.to_sym] = node.content
           end
         end
       end

--- a/lib/cldr/export/data_file.rb
+++ b/lib/cldr/export/data_file.rb
@@ -29,13 +29,23 @@ module Cldr
           end
           doc
         end
+
+        def filter_alt_values(doc)
+          # Until we determine how to handle alt values, we'll just remove them.
+          # TODO: https://github.com/ruby-i18n/ruby-cldr/issues/125
+          doc.traverse do |child|
+            next unless child.text?
+            child.parent.remove if child.parent.attribute("alt")
+          end
+          doc
+        end
       end
 
       attr_reader :doc, :minimum_draft_status
 
       def initialize(doc, minimum_draft_status: nil)
         @minimum_draft_status = minimum_draft_status || Cldr::Export.minimum_draft_status
-        @doc = Cldr::Export::DataFile.filter_by_draft(doc, @minimum_draft_status)
+        @doc = filter_data(doc)
       end
 
       def traverse(&block)
@@ -77,6 +87,14 @@ module Cldr
         end
 
         Cldr::Export::DataFile.new(result, minimum_draft_status: minimum_draft_status)
+      end
+
+      private
+
+      def filter_data(doc)
+        doc = Cldr::Export::DataFile.filter_by_draft(doc, minimum_draft_status)
+        doc = Cldr::Export::DataFile.filter_alt_values(doc)
+        doc
       end
     end
   end

--- a/test/export/data_file_test.rb
+++ b/test/export/data_file_test.rb
@@ -150,6 +150,46 @@ class TestDataFile < Test::Unit::TestCase
 
     assert_nil(parsed.locale)
   end
+
+  def test_alt_value_removal
+    xml_contents = <<~XML_CONTENTS
+      <?xml version="1.0" encoding="UTF-8" ?>
+      <ldml>
+        <identity>
+          <version number="$Revision$"/>
+          <language type="de"/>
+        </identity>
+        <localeDisplayNames>
+          <languages>
+            <language type="chy">Cheyenne</language>
+            <language type="ckb">Zentralkurdisch</language>
+            <language type="ckb" alt="menu">Kurdisch (Sorani)</language>
+            <language type="co">Korsisch</language>
+          </languages>
+        </localeDisplayNames>
+      </ldml>
+    XML_CONTENTS
+
+    parsed = Cldr::Export::DataFile.parse(xml_contents, minimum_draft_status: Cldr::DraftStatus::APPROVED)
+
+    expected = <<~XML_CONTENTS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <ldml>
+        <identity>
+          <version number="$Revision$"/>
+          <language type="de"/>
+        </identity>
+        <localeDisplayNames>
+          <languages>
+            <language type="chy">Cheyenne</language>
+            <language type="ckb">Zentralkurdisch</language>
+            <language type="co">Korsisch</language>
+          </languages>
+        </localeDisplayNames>
+      </ldml>
+    XML_CONTENTS
+    assert_equal(expected, parsed.doc.to_xml)
+  end
 end
 
 class TestDataFileDraftStatusFilter < Test::Unit::TestCase


### PR DESCRIPTION
### What are you trying to accomplish?

Values in CLDR can have an `alt` attribute. While we figure out how we want to export them, we should ignore them so they don't accidentally get output.

Ref #125.

### What approach did you choose and why?

`ruby-cldr` had a `alt?` method that was being used in a few places to ignore these values, but it wasn't being consistently.

I moved the filtering into `DataFile`, so the rest of the code doesn't even get a chance to see these values, so they can't possibly forget to remove them (thereby leaking them).

### What should reviewers focus on?

🤷 

### The impact of these changes

`alt` values are hidden and not exported.



### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [ ] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
