### PR TITLE
Inherit currency symbol instead of using other versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Export data at with a consistent minimum draft status, [#124](https://github.com/ruby-i18n/ruby-cldr/pull/124)
 - Add `--draft-status` flag for specifying the minimum draft status for data to be exported, [#124](https://github.com/ruby-i18n/ruby-cldr/pull/124)
 - Export locale-specific data files into `locales` subdirectory, [#135](https://github.com/ruby-i18n/ruby-cldr/pull/135)
+- Inherit currency symbol from ancestor locale instead of using other versions, [#137](https://github.com/ruby-i18n/ruby-cldr/pull/137)
 
 ---
 

--- a/lib/cldr/export/data/currencies.rb
+++ b/lib/cldr/export/data/currencies.rb
@@ -28,9 +28,10 @@ module Cldr
             end
           end
 
-          symbol = select(node, "symbol")
-          narrow_symbol = symbol.select { |child_node| child_node.values.include?("narrow") }.first
-          data[:symbol] = symbol.first.content unless symbol.empty?
+          symbols = select(node, "symbol")
+          symbol = symbols.select { |child_node| child_node.attribute("alt").nil? }.first
+          narrow_symbol = symbols.select { |child_node| child_node.attribute("alt")&.value == ("narrow") }.first
+          data[:symbol] = symbol.content unless symbol.nil?
           data[:narrow_symbol] = narrow_symbol.content unless narrow_symbol.nil?
 
           data


### PR DESCRIPTION
### What are you trying to accomplish?

The "narrow" version of the currency symbol is being used incorrectly for the currency symbol.

**Example**

CLDR has the following data for `TWD` in [`common/main/vi.xml`](https://github.com/unicode-org/cldr/blob/d2a6570323676eb002c47d756b25240a5357f4a0/common/main/vi.xml#L8766-L8771):

```xml
<currency type="TWD">
  <displayName>Đô la Đài Loan mới</displayName>
  <displayName count="other">Đô la Đài Loan mới</displayName>
  <symbol>↑↑↑</symbol>
  <symbol alt="narrow">NT$</symbol>
</currency>
```

[`cldr-staging`](https://github.com/unicode-org/cldr-staging) strips `↑↑↑` (explicit inheritance) markers, which means that file in the release is missing a non-`alt` version of the value:

```xml
<currency type="TWD">
  <displayName>Đô la Đài Loan mới</displayName>
  <displayName count="other">Đô la Đài Loan mới</displayName>
  <symbol alt="narrow">NT$</symbol>
</currency>
```

Before, `ruby-cldr` code was selecting the `alt="narrow"` version for the currency symbol, instead of relying on locale inheritance.

### What approach did you choose and why?

Explicitly select a version of the symbol that doesn't have an `alt` attribute.
Likewise for the the `alt="narrow"` version. We don't want to select the wrong one, if/when they add another attribute with a "narrow" value.

### What should reviewers focus on?

🤷

There was at least one case where it was exporting the `alt="variant"` version instead of the `alt="narrow"` version.

`common/main/fr_CA.xml`:

```xml
<currency type="TRY">
  <symbol alt="variant">TL</symbol>
</currency>
```

Support for exporting the `alt="variant"` version will be added in [a separate issue](https://github.com/ruby-i18n/ruby-cldr/issues/138).

### The impact of these changes

Less (more accurate) data exported. There were 398 instances where the wrong data was getting exported.

### Testing

```
git checkout main
thor cldr:export --components=Currencies --target=data_from_main
git checkout movermeyer/currency_alt_value_handling
thor cldr:export --components=Currencies --target=data_from_this_pr
diff -r data_from_main data_from_this_pr
```

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
