### PR TITLE
Validate our assumptions about the CLDR data

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,5 +35,5 @@ jobs:
       - name: Export the data
         run: bundle exec thor cldr:export
 
-      - name: Validate the data
+      - name: Validate the exported data
         run: bundle exec thor cldr:validate

--- a/lib/cldr/thor.rb
+++ b/lib/cldr/thor.rb
@@ -4,6 +4,7 @@ require "thor"
 require "cldr"
 require "cldr/download"
 require "cldr/validate"
+require "cldr/validate_upstream_assumptions"
 
 module Cldr
   class Thor < ::Thor
@@ -67,6 +68,11 @@ module Cldr
     end
 
     # TODO: flatten task, e.g. flatten all plural locale files into one big file
+
+    desc "validate_upstream", "Verify our assumptions about the CLDR data are correct."
+    def validate_upstream
+      Cldr::ValidateUpstreamAssumptions.validate
+    end
 
     desc "validate", "Run QA checks against the output data"
     option :target, aliases: [:t], type: :string,

--- a/lib/cldr/validate_upstream_assumptions.rb
+++ b/lib/cldr/validate_upstream_assumptions.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Cldr
+  class ValidateUpstreamAssumptions
+    class << self
+      def validate
+        errors = []
+        errors += validate_aliases_only_in_root_locale
+        errors += validate_aliases_only_in_expected_paths
+        errors.each do |error|
+          puts(error.message)
+        end
+        exit(errors.empty? ? 0 : 1)
+      end
+
+      private
+
+      def validate_aliases_only_in_root_locale
+        errors = []
+        Cldr::Export.minimum_draft_status = Cldr::DraftStatus::CONTRIBUTED
+        Cldr::Export::Data::RAW_DATA.locales.each do |locale|
+          aliases = Cldr::Export::Data::RAW_DATA[locale].xpath("//alias")
+          unless aliases.empty? || locale == :root
+            errors << StandardError.new("`#{locale}` has aliases but is not `root`")
+          end
+        end
+        errors
+      end
+
+      EXPECTED_ALIAS_LOCATIONS = [
+        "/ldml/dates/calendars/calendar/dayPeriods/dayPeriodContext/dayPeriodWidth/alias",
+        "/ldml/dates/calendars/calendar/days/dayContext/dayWidth/alias",
+        "/ldml/dates/calendars/calendar/months/monthContext/monthWidth/alias",
+        "/ldml/dates/calendars/calendar/quarters/quarterContext/quarterWidth/alias",
+      ].freeze
+
+      def validate_aliases_only_in_expected_paths
+        errors = []
+        Cldr::Export.minimum_draft_status = Cldr::DraftStatus::CONTRIBUTED
+        alias_paths = Cldr::Export::Data::RAW_DATA[:root].xpath("//alias").map do |child|
+          child.path.gsub(/\[\d+\]/, "")
+        end.sort.uniq
+
+        unknown_alias_paths = alias_paths - EXPECTED_ALIAS_LOCATIONS
+
+        if unknown_alias_paths
+          unknown_paths_string = unknown_alias_paths.join("\n\t")
+          errors << StandardError.new("Found unexpected aliases. Make sure ruby-cldr supports them, then update EXPECTED_ALIAS_LOCATIONS.\nFound an alias at the following unknown locations:\n\t#{unknown_paths_string}")
+        end
+
+        errors
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

`ruby-cldr` has baked in a number of assumptions about what is possible in the upstream data. Many bugs have been a result of the upstream data/specification changing and `ruby-cldr` not noticing.

Hopefully this will help us notice changes in the CLDR data that would cause us to need to refactor our code.

### What approach did you choose and why?

I added a `thor` task that we can run whenever we are going to upgrade the version of the CLDR data we are running against.

I added two assumptions from the start:

1) That `root` is the only locale that contains `alias` nodes
2) That `alias` nodes only appear in the places that we expect
* This currently fails, since we haven't implemented [support for exporting all the alias locations](https://github.com/ruby-i18n/ruby-cldr/issues/78) yet, so the `EXPECTED_ALIAS_LOCATIONS` list is incomplete.

### What should reviewers focus on?

🤷 

### The impact of these changes

Hopefully, with the addition of more assumptions, we will detect relevant changes to the CLDR spec before users report the issues. 

### Testing

```
thor cldr:validate_upstream
```