### PR TITLE
Add support for aliases in Gregorian eras

### DIFF
--- a/lib/cldr/export/data/calendars/gregorian.rb
+++ b/lib/cldr/export/data/calendars/gregorian.rb
@@ -83,14 +83,18 @@ module Cldr
 
           def eras
             if calendar
-              base_path = calendar.path.gsub("/ldml/", "") + "/eras"
+              base_path = calendar.path.sub(%r{^/ldml/}, "") + "/eras"
               keys = select("#{base_path}/*").map(&:name)
 
               keys.each_with_object({}) do |name, result|
                 path = "#{base_path}/#{name}/*"
                 key  = name.gsub("era", "").gsub(/s$/, "").downcase.to_sym
+
                 key_result = select(path).each_with_object({}) do |node, ret|
-                  next ret if node.name == "alias" # TODO: Actually handle alias nodes, https://github.com/ruby-i18n/ruby-cldr/issues/78
+                  if node.name == "alias"
+                    target = (node.attribute("path").value.match(%r{/([^\/]+)$}) && Regexp.last_match(1)).gsub("era", "").gsub(/s$/, "").downcase
+                    break :"calendars.gregorian.eras.#{target}"
+                  end
 
                   type = node.attribute("type").value.to_i
                   ret[type] = node.content

--- a/lib/cldr/validate_upstream_assumptions.rb
+++ b/lib/cldr/validate_upstream_assumptions.rb
@@ -30,6 +30,13 @@ module Cldr
       EXPECTED_ALIAS_LOCATIONS = [
         "/ldml/dates/calendars/calendar/dayPeriods/dayPeriodContext/dayPeriodWidth/alias",
         "/ldml/dates/calendars/calendar/days/dayContext/dayWidth/alias",
+
+        # Currently only used by `islamic-*` calendars, which we don't export yet.
+        # https://github.com/ruby-i18n/ruby-cldr/issues/168
+        "/ldml/dates/calendars/calendar/eras/alias",
+
+        "/ldml/dates/calendars/calendar/eras/eraNames/alias",
+        "/ldml/dates/calendars/calendar/eras/eraNarrow/alias",
         "/ldml/dates/calendars/calendar/months/monthContext/monthWidth/alias",
         "/ldml/dates/calendars/calendar/quarters/quarterContext/quarterWidth/alias",
       ].freeze

--- a/test/export/data/calendars_test.rb
+++ b/test/export/data/calendars_test.rb
@@ -197,13 +197,14 @@ class TestCldrDataCalendars < Test::Unit::TestCase
     assert_equal ["abbreviated", "narrow", "wide"], gregorian(merged: true)[:months][:"stand-alone"].keys.map(&:to_s).sort
   end
 
-  test "calendars for :root only contains `abbr` since we do not yet handle alias nodes" do
-    # https://github.com/ruby-i18n/ruby-cldr/issues/78
+  test "Gregorian eras for :root contains the expected alias nodes" do
     eras = {
       abbr: {
         0 => "BCE",
         1 => "CE",
       },
+      name: :"calendars.gregorian.eras.abbr",
+      narrow: :"calendars.gregorian.eras.abbr",
     }
     assert_equal eras, gregorian(locale: :root)[:eras]
   end


### PR DESCRIPTION
### What are you trying to accomplish?

Part of #78. Adding support for aliases within the `eras` elements.

### What approach did you choose and why?

Added specific handling for `alias` nodes at that specific path.
Then added the path to `validate_aliases_only_in_expected_paths` so that the list remaining alias locations gets smaller.

### What should reviewers focus on?

I didn't add support for aliases at `/ldml/dates/calendars/calendar/eras`, but they are only present in non-Gregorian calendars, and we [don't yet export](#168) those.

(I wonder if there's a nice way to change `validate_aliases_only_in_expected_paths` to also check this assertion 🤔) 

### The impact of these changes

Three less alias locations to handle.

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
