### PR TITLE
Add alias support in Fields, Lists, and Units components

### DIFF
--- a/lib/cldr/export/data/lists.rb
+++ b/lib/cldr/export/data/lists.rb
@@ -18,11 +18,33 @@ module Cldr
             else
               :default
             end
-
-            list_pattern_ret[pattern_type] = select(list_pattern, "listPatternPart").each_with_object({}) do |part, part_ret|
-              part_ret[part.attribute("type").value.to_sym] = part.content
-            end
+            list_pattern_ret[pattern_type] = list_pattern(list_pattern)
           end
+        end
+
+        def list_pattern(list_pattern)
+          aliased = select(list_pattern, "alias").first
+          if aliased
+            xpath_to_key(aliased.attribute("path").value)
+          else
+            get_pattern_parts(list_pattern)
+          end
+        end
+
+        def get_pattern_parts(list_pattern)
+          select(list_pattern, "listPatternPart").each_with_object({}) do |part, part_ret|
+            part_ret[part.attribute("type").value.to_sym] = part.content
+          end
+        end
+
+        def xpath_to_key(xpath)
+          return :"lists.default" if xpath == "../listPattern"
+
+          match = xpath.match(%r{^\.\./listPattern\[@type='([^']*)'\]$})
+          raise StandardError, "Didn't find expected data in alias path attribute: #{xpath}" unless match
+
+          type = match[1]
+          :"lists.#{type}"
         end
       end
     end

--- a/lib/cldr/export/data/units.rb
+++ b/lib/cldr/export/data/units.rb
@@ -23,12 +23,18 @@ module Cldr
         end
 
         def units(node)
+          aliased = select(node, "alias").first
+          return units_xpath_to_key(aliased.attribute("path").value) if aliased
+
           node.xpath("unit").each_with_object({}) do |node, result|
             result[node.attribute("type").value.to_sym] = unit(node)
           end
         end
 
         def unit(node)
+          aliased = select(node, "alias").first
+          return unit_xpath_to_key(aliased.attribute("path").value) if aliased
+
           node.xpath("unitPattern").each_with_object({}) do |node, result|
             # Ignore cases for now. We don't have a way to expose them yet.
             # TODO: https://github.com/ruby-i18n/ruby-cldr/issues/67
@@ -43,6 +49,22 @@ module Cldr
           select("units/durationUnit").each_with_object({}) do |node, result|
             result[node.attribute("type").value.to_sym] = node.xpath("durationUnitPattern").first.content
           end
+        end
+
+        def units_xpath_to_key(xpath)
+          match = xpath.match(%r{^\.\./unitLength\[@type='([^']*)'\]$})
+          raise StandardError, "Didn't find expected data in alias path attribute: #{xpath}" unless match
+
+          type = match[1]
+          :"units.unitLength.#{type}"
+        end
+
+        def unit_xpath_to_key(xpath)
+          match = xpath.match(%r{^\.\./unit\[@type='([^']*)'\]$})
+          raise StandardError, "Didn't find expected data in alias path attribute: #{xpath}" unless match
+
+          type = match[1]
+          :"units.unitLength.short.#{type}"
         end
       end
     end

--- a/lib/cldr/validate_upstream_assumptions.rb
+++ b/lib/cldr/validate_upstream_assumptions.rb
@@ -34,6 +34,10 @@ module Cldr
         "/ldml/dates/calendars/calendar/days/dayContext/dayWidth/alias",
         "/ldml/dates/calendars/calendar/months/monthContext/monthWidth/alias",
         "/ldml/dates/calendars/calendar/quarters/quarterContext/quarterWidth/alias",
+        "/ldml/dates/fields/field/alias",
+        "/ldml/listPatterns/listPattern/alias",
+        "/ldml/units/unitLength/alias",
+        "/ldml/units/unitLength/unit/alias",
       ].freeze
 
       # Alias locations that exist, but we don't support, since we don't export this data.

--- a/test/export/data/fields_test.rb
+++ b/test/export/data/fields_test.rb
@@ -1,0 +1,24 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+require File.expand_path(File.join(File.dirname(__FILE__) + "/../../test_helper"))
+
+class TestCldrDataFields < Test::Unit::TestCase
+  test "Alias nodes are exported as paths to their targets" do
+    data = Cldr::Export::Data::Fields.new(:root)
+    path = data.dig(:fields, :"day-narrow")
+    assert_equal :"fields.day-short", path
+
+    path = data.dig(*split_path_string(path))
+    assert_equal :"fields.day", path
+
+    day = data.dig(*split_path_string(path))
+    assert_not_nil day
+  end
+
+  private
+
+  def split_path_string(path)
+    path.to_s.split(".").map(&:to_sym)
+  end
+end

--- a/test/export/data/lists_test.rb
+++ b/test/export/data/lists_test.rb
@@ -1,0 +1,24 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+require File.expand_path(File.join(File.dirname(__FILE__) + "/../../test_helper"))
+
+class TestCldrDataLists < Test::Unit::TestCase
+  test "Alias nodes are exported as paths to their targets" do
+    data = Cldr::Export::Data::Lists.new(:root)
+    path = data.dig(:lists, :"or-narrow")
+    assert_equal :"lists.or-short", path
+
+    path = data.dig(*split_path_string(path))
+    assert_equal :"lists.or", path
+
+    pattern_or = data.dig(*split_path_string(path))
+    assert_not_nil pattern_or
+  end
+
+  private
+
+  def split_path_string(path)
+    path.to_s.split(".").map(&:to_sym)
+  end
+end

--- a/test/export/data/units_test.rb
+++ b/test/export/data/units_test.rb
@@ -25,4 +25,19 @@ class TestCldrDataUnits < Test::Unit::TestCase
     assert_equal units[:minute], data[:"duration-minute"]
     assert_equal units[:second], data[:"duration-second"]
   end
+
+  test "Alias nodes are exported as paths to their targets" do
+    data = Cldr::Export::Data::Units.new(:root)
+    path = data.dig(:units, :unitLength, :short, :"duration-week-person")
+    assert_equal :"units.unitLength.short.duration-week", path
+
+    duration = data.dig(*split_path_string(path))
+    assert_not_nil duration
+  end
+
+  private
+
+  def split_path_string(path)
+    path.to_s.split(".").map(&:to_sym)
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->

Add alias support to components `Fields`, `Lists`, and `Units` as part of #78. 

### What approach did you choose and why?
<!--
There are many ways to solve a problem. How did you approach this problem and why?
-->

- Added handling for `alias` nodes which were previously skipped while components iterated through all nodes
- Updated `validate_upstream_assumptions.rb` to include corresponding expected paths

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

`units.rb` has a lot of hardcoded information based on the way files are currently formatted by cldr. While it currently works, I wonder if there's a better way to iterate through the nodes.

### The impact of these changes
<!--
Are there any specific impacts from this change that you'd like to call out?
-->

Furthers alias support as outlined in #78.

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

Created unit tests for each component and manually verified exported data.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
