### PR TITLE
Exclude aliases that are for data that we do not export

### DIFF
--- a/lib/cldr/validate_upstream_assumptions.rb
+++ b/lib/cldr/validate_upstream_assumptions.rb
@@ -27,11 +27,21 @@ module Cldr
         errors
       end
 
-      EXPECTED_ALIAS_LOCATIONS = [
+      # Aliases need explicit special handling. Once that handling has been added,
+      # the path covered by the handling gets added to this list.
+      SUPPORTED_ALIAS_LOCATIONS = [
         "/ldml/dates/calendars/calendar/dayPeriods/dayPeriodContext/dayPeriodWidth/alias",
         "/ldml/dates/calendars/calendar/days/dayContext/dayWidth/alias",
         "/ldml/dates/calendars/calendar/months/monthContext/monthWidth/alias",
         "/ldml/dates/calendars/calendar/quarters/quarterContext/quarterWidth/alias",
+      ].freeze
+
+      # Alias locations that exist, but we don't support, since we don't export this data.
+      # Note: We don't have anything that will catch us if/when we start exporting this data.
+      UNUSED_ALIAS_LOCATIONS = [
+        "/ldml/dates/calendars/calendar/cyclicNameSets/alias",
+        "/ldml/dates/calendars/calendar/cyclicNameSets/cyclicNameSet/alias",
+        "/ldml/dates/calendars/calendar/cyclicNameSets/cyclicNameSet/cyclicNameContext/cyclicNameWidth/alias",
       ].freeze
 
       def validate_aliases_only_in_expected_paths
@@ -41,11 +51,11 @@ module Cldr
           child.path.gsub(/\[\d+\]/, "")
         end.sort.uniq
 
-        unknown_alias_paths = alias_paths - EXPECTED_ALIAS_LOCATIONS
+        unknown_alias_paths = alias_paths - SUPPORTED_ALIAS_LOCATIONS - UNUSED_ALIAS_LOCATIONS
 
         if unknown_alias_paths
           unknown_paths_string = unknown_alias_paths.join("\n\t")
-          errors << StandardError.new("Found unexpected aliases. Make sure ruby-cldr supports them, then update EXPECTED_ALIAS_LOCATIONS.\nFound an alias at the following unknown locations:\n\t#{unknown_paths_string}")
+          errors << StandardError.new("Found unexpected aliases. Make sure ruby-cldr supports them, then update SUPPORTED_ALIAS_LOCATIONS or UNUSED_ALIAS_LOCATIONS.\nFound an alias at the following unknown locations:\n\t#{unknown_paths_string}")
         end
 
         errors


### PR DESCRIPTION
### What are you trying to accomplish?

Removed some of the aliases from the list that we won't support since we don't export that data (yet).

### What approach did you choose and why?

Added a second list, renamed the existing list, and added comments explaining the reasons for each.

### What should reviewers focus on?

If we are ever to start exporting this data, we'll need to remember to remove it from this list.

I spent a while mulling over the idea of having a mechanism that complained it we were to ever export data from these paths in the future. But that felt like overkill for right now.

I might change this code to output the full ["element chain"](https://www.unicode.org/reports/tr35/tr35.html#Definitions) that CLDR uses to refer to elements. But that will be a different PR.

### The impact of these changes

Reduces the list put out by `thor cldr:validate_upstream`

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
