### PR TITLE
Fix `numbers.rb` ignoring distinguishing attribute numberSystem

### DIFF
--- a/lib/cldr/export/data/numbers.rb
+++ b/lib/cldr/export/data/numbers.rb
@@ -41,7 +41,7 @@ module Cldr
         end
 
         def symbols
-          select("numbers/symbols/*").each_with_object({}) do |node, result|
+          select("numbers/symbols[@numberSystem=\"latn\"]/*").each_with_object({}) do |node, result|
             result[name(node).to_sym] = node.content
           end
         end


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->

Fix `Cldr::Export::Data::Numbers#symbols` ignoring distinguishing attribute `numberSystem` issue as described in #79. 

### What approach did you choose and why?
<!--
There are many ways to solve a problem. How did you approach this problem and why?
-->

Set `Cldr::Export::Data::Numbers#symbols` to explicitly target `latn` number system instead of merging all numbering systems and relying on 'latn' being at the end.

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

This only exports the `latn` number system as that is what is currently being done, but support for all number systems in the future could be considered (see #167).

### The impact of these changes
<!--
Are there any specific impacts from this change that you'd like to call out?
-->

Removes `alias` key from exported symbols, which was a result of merging all numbering systems. However, it had an empty value and does not exist in `latn`, so it is unneeded.

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

Manually checked exported data.

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
