### PR TITLE
Export region validity data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add `--draft-status` flag for specifying the minimum draft status for data to be exported, [#124](https://github.com/ruby-i18n/ruby-cldr/pull/124)
 - Export locale-specific data files into `locales` subdirectory, [#135](https://github.com/ruby-i18n/ruby-cldr/pull/135)
 - Inherit currency symbol from ancestor locale instead of using other versions, [#137](https://github.com/ruby-i18n/ruby-cldr/pull/137)
+- Export region validity data, [#179](https://github.com/ruby-i18n/ruby-cldr/pull/179)
 
 ---
 

--- a/lib/cldr/export.rb
+++ b/lib/cldr/export.rb
@@ -24,7 +24,7 @@ module Cldr
     SHARED_COMPONENTS = [
       :Aliases, :CountryCodes, :CurrencyDigitsAndRounding, :LikelySubtags,
       :Metazones, :NumberingSystems, :ParentLocales, :RbnfRoot,
-      :RegionCurrencies, :SegmentsRoot, :TerritoriesContainment,
+      :RegionCurrencies, :RegionValidity, :SegmentsRoot, :TerritoriesContainment,
       :Transforms, :Variables, :WindowsZones,
     ].freeze
 

--- a/lib/cldr/export/data.rb
+++ b/lib/cldr/export/data.rb
@@ -27,6 +27,7 @@ module Cldr
       autoload :Rbnf,                      "cldr/export/data/rbnf"
       autoload :RbnfRoot,                  "cldr/export/data/rbnf_root"
       autoload :RegionCurrencies,          "cldr/export/data/region_currencies"
+      autoload :RegionValidity,            "cldr/export/data/region_validity"
       autoload :SegmentsRoot,              "cldr/export/data/segments_root"
       autoload :Subdivisions,              "cldr/export/data/subdivisions"
       autoload :Territories,               "cldr/export/data/territories"

--- a/lib/cldr/export/data/region_validity.rb
+++ b/lib/cldr/export/data/region_validity.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Cldr
+  module Export
+    module Data
+      class RegionValidity < Base
+        def initialize
+          super(nil)
+          update(validity: { regions: regions })
+        end
+
+        private
+
+        def regions
+          doc.xpath("/supplementalData/idValidity/id[@type='region']").each_with_object({}) do |node, hash|
+            type = node.attribute("idStatus").to_s.to_sym
+            hash[type] = node.content.split(/\s+/).map(&:strip).reject(&:empty?).flat_map { |element| expand_range(*element.split("~")) }
+          end
+        end
+
+        def expand_range(start, endd = nil)
+          return [start] if endd.nil?
+
+          prefix = start[0...-1]
+          ((start[-1].ord)..(endd.ord)).map(&:chr).map { |c| "#{prefix}#{c}" }
+        end
+      end
+    end
+  end
+end

--- a/test/export/data/region_validity_test.rb
+++ b/test/export/data/region_validity_test.rb
@@ -1,0 +1,30 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+require File.expand_path(File.join(File.dirname(__FILE__) + "/../../test_helper"))
+
+class TestCldrDataRegionValidity < Test::Unit::TestCase
+  test "region validity" do
+    region_validity = Cldr::Export::Data::RegionValidity.new[:validity][:regions]
+    assert_include(region_validity[:regular], "AD")
+    assert_equal(region_validity[:regular].size, 256)
+
+    assert_include(region_validity[:special], "XB")
+    assert_equal(region_validity[:special].size, 2)
+
+    assert_include(region_validity[:macroregion], "002")
+    assert_equal(region_validity[:macroregion].size, 35)
+
+    assert_include(region_validity[:deprecated], "YU")
+    assert_equal(region_validity[:deprecated].size, 12)
+
+    assert_include(region_validity[:reserved], "QN")
+    assert_equal(region_validity[:reserved].size, 13)
+
+    assert_include(region_validity[:private_use], "XD")
+    assert_equal(region_validity[:private_use].size, 23)
+
+    assert_include(region_validity[:unknown], "ZZ")
+    assert_equal(region_validity[:unknown].size, 1)
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #178

### What approach did you choose and why?

I dumped the data in CLDR into YAML in a fairly direct way:

```yaml
---
validity:
  regions:
    deprecated:
    - AN
    - BU
    ...
    macroregion:
    - '001'
    ...
```

I expanded the range syntax of CLDR so that consumers don't have to know anything about it.

### What should reviewers focus on?

🤷 

### The impact of these changes

There is a new component for consumers to use. They'll be able to use this data to ensure that they are handling all the values that CLDR uses for regions.

### Testing

```
thor cldr:export --components=RegionValidity
```

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
