### PR TITLE
Fail if we expect to find a single entry, but find multiple

### DIFF
--- a/lib/cldr/export/data/base.rb
+++ b/lib/cldr/export/data/base.rb
@@ -31,6 +31,13 @@ module Cldr
           doc.xpath(xpath(sources))
         end
 
+        def select_single(*sources)
+          results = doc.xpath(xpath(sources))
+          raise "#{locale || "<supplemental>"}: Expected 1 result for `#{sources}`, got #{results.size}" if results.size > 1
+
+          results.first
+        end
+
         def xpath(sources)
           path = sources.map { |source| source.respond_to?(:path) ? source.path : source }.join("/")
           path =~ %r{^/?/ldml} ? path : "//ldml/#{path}"

--- a/lib/cldr/export/data/calendars/gregorian.rb
+++ b/lib/cldr/export/data/calendars/gregorian.rb
@@ -24,7 +24,7 @@ module Cldr
           end
 
           def calendar
-            @calendar ||= select('dates/calendars/calendar[@type="gregorian"]').first
+            @calendar ||= select_single('dates/calendars/calendar[@type="gregorian"]')
           end
 
           def contexts(kind, options = {})
@@ -42,7 +42,7 @@ module Cldr
           end
 
           def elements(node, kind, context, width, options = {})
-            aliased = select(node, "alias").first
+            aliased = select_single(node, "alias")
 
             if aliased
               xpath_to_key(aliased.attribute("path").value, kind, context, width)
@@ -72,8 +72,8 @@ module Cldr
           end
 
           def periods
-            am = select(calendar, "am").first
-            pm = select(calendar, "pm").first
+            am = select_single(calendar, "am")
+            pm = select_single(calendar, "pm")
 
             result = {}
             result[:am] = am.content if am
@@ -133,7 +133,7 @@ module Cldr
           end
 
           def default_format(type)
-            if (node = select(calendar, "#{type}Formats/default").first)
+            if (node = select_single(calendar, "#{type}Formats/default"))
               key = node.attribute("choice").value.to_sym
               { default: :"calendars.gregorian.formats.#{type.downcase}.#{key}" }
             end

--- a/lib/cldr/export/data/delimiters.rb
+++ b/lib/cldr/export/data/delimiters.rb
@@ -19,8 +19,8 @@ module Cldr
         private
 
         def quotes(type)
-          start = select("delimiters/#{type}Start").first
-          end_  = select("delimiters/#{type}End").first
+          start = select_single("delimiters/#{type}Start")
+          end_  = select_single("delimiters/#{type}End")
 
           result = {}
           result[:start] = start.content if start

--- a/lib/cldr/export/data/fields.rb
+++ b/lib/cldr/export/data/fields.rb
@@ -19,7 +19,7 @@ module Cldr
         end
 
         def field(field_node)
-          aliased = select(field_node, "alias").first
+          aliased = select_single(field_node, "alias")
           return xpath_to_key(aliased.attribute("path").value) if aliased
 
           result = {}

--- a/lib/cldr/export/data/layout.rb
+++ b/lib/cldr/export/data/layout.rb
@@ -14,7 +14,7 @@ module Cldr
         def layout
           result = { orientation: {} }
 
-          if (node = select("layout/orientation/characterOrder/text()").first)
+          if (node = select_single("layout/orientation/characterOrder/text()"))
             result[:orientation][:character_order] = node.text
           end
 

--- a/lib/cldr/export/data/lists.rb
+++ b/lib/cldr/export/data/lists.rb
@@ -23,7 +23,7 @@ module Cldr
         end
 
         def list_pattern(list_pattern)
-          aliased = select(list_pattern, "alias").first
+          aliased = select_single(list_pattern, "alias")
           if aliased
             xpath_to_key(aliased.attribute("path").value)
           else

--- a/lib/cldr/export/data/numbers.rb
+++ b/lib/cldr/export/data/numbers.rb
@@ -78,7 +78,7 @@ module Cldr
                 end
               end
             else
-              aliased = select(format_length_node, "alias").first
+              aliased = select_single(format_length_node, "alias")
 
               if aliased
                 format_result[format_key] = xpath_to_redirect(aliased.attribute("path").value)

--- a/lib/cldr/export/data/timezones.rb
+++ b/lib/cldr/export/data/timezones.rb
@@ -35,7 +35,7 @@ module Cldr
             result[type][:long] = long unless long.empty?
             short = nodes_to_hash(zone.xpath("short/*"))
             result[type][:short] = short unless short.empty?
-            city = select_single(zone, "exemplarCity")
+            city = select_single(zone, "exemplarCity[not(@alt)]")
             result[type][:city] = city.content if city
           end
         end

--- a/lib/cldr/export/data/timezones.rb
+++ b/lib/cldr/export/data/timezones.rb
@@ -35,7 +35,7 @@ module Cldr
             result[type][:long] = long unless long.empty?
             short = nodes_to_hash(zone.xpath("short/*"))
             result[type][:short] = short unless short.empty?
-            city = select(zone, "exemplarCity").first
+            city = select_single(zone, "exemplarCity")
             result[type][:city] = city.content if city
           end
         end

--- a/lib/cldr/export/data/units.rb
+++ b/lib/cldr/export/data/units.rb
@@ -23,7 +23,7 @@ module Cldr
         end
 
         def units(node)
-          aliased = select(node, "alias").first
+          aliased = select_single(node, "alias")
           return units_xpath_to_key(aliased.attribute("path").value) if aliased
 
           node.xpath("unit").each_with_object({}) do |node, result|
@@ -32,7 +32,7 @@ module Cldr
         end
 
         def unit(node)
-          aliased = select(node, "alias").first
+          aliased = select_single(node, "alias")
           return unit_xpath_to_key(aliased.attribute("path").value) if aliased
 
           node.xpath("unitPattern").each_with_object({}) do |node, result|


### PR DESCRIPTION
### What are you trying to accomplish?

While working on `Numbers`, I noticed that there were some `select` statements that were expecting a single result, since they were followed by a `first`.

However, this leads to issues/bugs when the provided XPath is not specific enough, and there are accidentally multiple matches. The code ends up picking the first one it finds arbitrarily, leading to subtle bugs.

### What approach did you choose and why?

Instead of using the `select...first` pattern, I combined it into a new `select_single` method that explodes if the provided XPath matched multiple nodes. 

I then fixed an instance where it was failing since the XPath was also matching the `alt` version of the timezone name.

### What should reviewers focus on?

I left a single instance of `select...first` pattern in `Numbers`. It's a legitimate bug, but is not easily addressed in this PR. I'll be fixing that as part of my work on #167

### The impact of these changes

More safety.

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [x] ~I have added a CHANGELOG entry for this change (or determined that it isn't needed)~
