### PR TITLE
Remove some unused code

### DIFF
--- a/lib/cldr/export/data/calendars/gregorian.rb
+++ b/lib/cldr/export/data/calendars/gregorian.rb
@@ -68,19 +68,6 @@ module Cldr
             :"calendars.gregorian.#{kind}s.#{context}.#{width}"
           end
 
-          def xpath_width
-          end
-
-          def periods
-            am = select_single(calendar, "am")
-            pm = select_single(calendar, "pm")
-
-            result = {}
-            result[:am] = am.content if am
-            result[:pm] = pm.content if pm
-            result
-          end
-
           def eras
             if calendar
               base_path = calendar.path.sub(%r{^/ldml/}, "") + "/eras"


### PR DESCRIPTION
### What are you trying to accomplish?

Noticed some unused code.

- `xpath_width` was added in https://github.com/ruby-i18n/ruby-cldr/commit/7c626a8c7cc3820f22ae3cbe312f5a7d5ce6e2c1 and never used/implemented.
- `periods` was added in https://github.com/ruby-i18n/ruby-cldr/commit/666446429d46c760afc9c6b3291a24ba1668e890 and stopped being used in https://github.com/ruby-i18n/ruby-cldr/commit/2af2d48ebe770200966405b4e9f77b0a838b0bdb

### What approach did you choose and why?

🔥 

### What should reviewers focus on?

🤷 

### The impact of these changes

No difference in exported data. Just less methods.

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
