### PR TITLE
Add prerelease flag to download

### DIFF
--- a/lib/cldr/download.rb
+++ b/lib/cldr/download.rb
@@ -11,7 +11,17 @@ module Cldr
     DEFAULT_VERSION = 41
 
     class << self
-      def download(source = DEFAULT_SOURCE, target = DEFAULT_TARGET, version = DEFAULT_VERSION, &block)
+      def download(source = DEFAULT_SOURCE, target = DEFAULT_TARGET, version = DEFAULT_VERSION, pre_release: false, &block)
+        if pre_release
+          download_prerelease(source, target, version, &block)
+        else
+          download_release(source, target, version, &block)
+        end
+      end
+
+      private
+
+      def download_release(source, target, version, &block)
         source = format(source, version: version)
         target ||= File.expand_path(DEFAULT_TARGET)
 
@@ -24,6 +34,27 @@ module Cldr
               FileUtils.mkdir_p(File.dirname(path))
               file.extract(entry, path)
               yield path
+            end
+          end
+        end
+      end
+
+      def download_prerelease(source, target, version, &block)
+        source = format(source, version: version)
+        target ||= File.expand_path(DEFAULT_TARGET)
+
+        URI.parse(source).open do |tempfile|
+          FileUtils.mkdir_p(target)
+          Zip.on_exists_proc = true
+          Zip::File.open(tempfile.path) do |file|
+            root_dir = file.first.name
+            production_dir = root_dir + "production"
+            file.each do |entry|
+              next unless entry.name.start_with?(production_dir)
+
+              path = target + "/" + entry.name.gsub(production_dir, "")
+              FileUtils.mkdir_p(File.dirname(path))
+              file.extract(entry, path)
             end
           end
         end

--- a/lib/cldr/thor.rb
+++ b/lib/cldr/thor.rb
@@ -10,7 +10,7 @@ module Cldr
   class Thor < ::Thor
     namespace "cldr"
 
-    desc "download [--version=#{Cldr::Download::DEFAULT_VERSION}] [--target=#{Cldr::Download::DEFAULT_TARGET}] [--source=#{format(Cldr::Download::DEFAULT_SOURCE, version: Cldr::Download::DEFAULT_VERSION)}]", "Download and extract CLDR data"
+    desc "download [--version=#{Cldr::Download::DEFAULT_VERSION}] [--target=#{Cldr::Download::DEFAULT_TARGET}] [--source=#{format(Cldr::Download::DEFAULT_SOURCE, version: Cldr::Download::DEFAULT_VERSION)}] [--pre-release]", "Download and extract CLDR data"
     option :version, aliases: [:v], type: :numeric,
       default: Cldr::Download::DEFAULT_VERSION,
       banner: Cldr::Download::DEFAULT_VERSION,
@@ -23,8 +23,11 @@ module Cldr
       default: Cldr::Download::DEFAULT_SOURCE,
       banner: Cldr::Download::DEFAULT_SOURCE,
       desc: "Override the location of the CLDR zip to download. Overrides --version"
+    option :"pre-release", type: :boolean,
+      default: false,
+      desc: "Whether the source is a pre-release version"
     def download
-      Cldr::Download.download(options["source"], options["target"], options["version"]) { putc(".") }
+      Cldr::Download.download(options["source"], options["target"], options["version"], pre_release: options["pre-release"]) { putc(".") }
     end
 
     DEFAULT_MINIMUM_DRAFT_STATUS = Cldr::DraftStatus::CONTRIBUTED


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->

Add a prerelease flag to `thor cldr:download` to quickly test prerelease versions of cldr from sources such as [this one.](https://github.com/unicode-org/cldr-staging/releases/tag/release-42-alpha3)

### What approach did you choose and why?
<!--
There are many ways to solve a problem. How did you approach this problem and why?
-->

Prerelease versions of cldr contain needed files under `production/`, which differs from the directory structure of released versions. This means that in order to test them, they must be manually downloaded and parsed to `vendor/`.

As a solution, a separate `download#download_prerelease` function has been added that only extracts `production/` from a given source, such that the files extracted to `vendor/` result in the expected directory structure.

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

Prereleases in https://github.com/unicode-org/cldr-staging/releases are very large (~1.5gb). In the future it would be nice to find a way to only download needed files as the large majority of the compressed file consists of documentation.

### The impact of these changes
<!--
Are there any specific impacts from this change that you'd like to call out?
-->

By regularly testing prerelease versions of cldr, preparations for upcoming changes can be made, allowing for quicker upgrades to released versions.

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

Manually checked that file is properly extracted to `vendor/`, and that the extracted files are used as expected.

### Checklist

* [ ] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
