### PR TITLE
Export <contextTransforms> data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Export region validity data, [#179](https://github.com/ruby-i18n/ruby-cldr/pull/179)
 - `Layout` component no longer exports files unless they contain data, [#183](https://github.com/ruby-i18n/ruby-cldr/pull/183)
 - Sort the data at the component level, allowing components to specify their own sort orders, [#200](https://github.com/ruby-i18n/ruby-cldr/pull/200)
+- Export `<contextTransforms>` data, [#206](https://github.com/ruby-i18n/ruby-cldr/pull/206)
 
 ---
 

--- a/lib/cldr/export/data.rb
+++ b/lib/cldr/export/data.rb
@@ -9,6 +9,7 @@ module Cldr
       autoload :Base,                      "cldr/export/data/base"
       autoload :Calendars,                 "cldr/export/data/calendars"
       autoload :Characters,                "cldr/export/data/characters"
+      autoload :ContextTransforms,         "cldr/export/data/context_transforms"
       autoload :CountryCodes,              "cldr/export/data/country_codes"
       autoload :Currencies,                "cldr/export/data/currencies"
       autoload :CurrencyDigitsAndRounding, "cldr/export/data/currency_digits_and_rounding"

--- a/lib/cldr/export/data/context_transforms.rb
+++ b/lib/cldr/export/data/context_transforms.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Cldr
+  module Export
+    module Data
+      class ContextTransforms < Base
+        def initialize(locale)
+          super
+          update(context_transforms: context_transforms)
+        end
+
+        private
+
+        def context_transforms
+          @context_transforms ||= select("contextTransforms/contextTransformUsage").each_with_object({}) do |usage_node, result|
+            usage_type = usage_node.attribute("type").value.to_sym
+            result[usage_type] = usage_node.xpath("contextTransform").each_with_object({}) do |transform_node, result|
+              transform_type = transform_node.attribute("type").value.to_sym
+              result[transform_type] = transform_node.content
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

CLDR does translations of ["Display names"](https://www.unicode.org/reports/tr35/tr35-general.html#Display_Name_Elements) (e.g. Language names, territory names, etc.) with the "capitalization ... intended to be the form used in the middle of running text".

It then defines [`<contextTransforms>` data](https://www.unicode.org/reports/tr35/tr35-general.html#Context_Transform_Elements) to describe how these names should be capitalized in other contexts.

### What approach did you choose and why?

I threw together a component that exports the `<contextTransforms>` data in a very direct way: a straight-forward conversion from XML to YAML.

### What should reviewers focus on?

Perhaps in the future it would make sense to also expose methods that implement these transforms. Or simply make use of this data as part of a higher level API.

For now, we'll keep it simple.

Also, the key names are a gross mix of snake_case, camelCase, and kebab-case. This is because CLDR is inconsistent. I'll leave it to a future PR to consider standardizing on snake_case for everything.

### The impact of these changes

Users of `ruby-cldr` will be able to access this data in their applications.

### Testing

`thor cldr:export --components=ContextTransforms`


`data/locales/en/context_transforms.yml`:

```yaml
---
en:
  context_transforms:
    calendar-field:
      stand-alone: titlecase-firstword
      uiListOrMenu: titlecase-firstword
    keyValue:
      stand-alone: titlecase-firstword
      uiListOrMenu: titlecase-firstword
    number-spellout:
      stand-alone: titlecase-firstword
      uiListOrMenu: titlecase-firstword
    relative:
      stand-alone: titlecase-firstword
      uiListOrMenu: titlecase-firstword
    typographicNames:
      stand-alone: titlecase-firstword
      uiListOrMenu: titlecase-firstword
```

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
