### PR TITLE
Standardize key names to snake_case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Sort the data at the component level, allowing components to specify their own sort orders, [#200](https://github.com/ruby-i18n/ruby-cldr/pull/200)
 - Export `<contextTransforms>` data, [#206](https://github.com/ruby-i18n/ruby-cldr/pull/206)
 - `Numbers` component now outputs data from all number systems, [#189](https://github.com/ruby-i18n/ruby-cldr/pull/189)
+- Use `snake_case` for key names unless they are an external identifier, [#207](https://github.com/ruby-i18n/ruby-cldr/pull/207)
 
 ---
 

--- a/lib/cldr/export.rb
+++ b/lib/cldr/export.rb
@@ -3,6 +3,7 @@
 require "i18n"
 require "fileutils"
 require "i18n/locale/tag"
+require "cldr/export/deep_validate_keys"
 require "core_ext/string/camelize"
 require "core_ext/string/underscore"
 require "core_ext/hash/deep_stringify"

--- a/lib/cldr/export/data/calendars/gregorian.rb
+++ b/lib/cldr/export/data/calendars/gregorian.rb
@@ -29,7 +29,7 @@ module Cldr
 
           def contexts(kind, options = {})
             select(calendar, "#{kind}s/#{kind}Context").each_with_object({}) do |node, result|
-              context = node.attribute("type").value.to_sym
+              context = node.attribute("type").value.underscore.to_sym
               result[context] = widths(node, kind, context, options)
             end
           end
@@ -49,7 +49,7 @@ module Cldr
             else
               select(node, kind).each_with_object({}) do |node, result|
                 key = node.attribute("type").value
-                key = key =~ /^\d*$/ ? key.to_i : key.to_sym
+                key = key =~ /^\d*$/ ? key.to_i : key.underscore.to_sym
 
                 if options[:group] && (found_group = node.attribute(options[:group]))
                   result[found_group.value.to_sym] ||= {}
@@ -63,7 +63,7 @@ module Cldr
 
           def xpath_to_key(xpath, kind, context, width)
             kind    = (xpath =~ %r(/([^\/]*)Width) && Regexp.last_match(1)) || kind
-            context = (xpath =~ %r(Context\[@type='([^\/]*)'\]) && Regexp.last_match(1)) || context
+            context = (xpath =~ %r(Context\[@type='([^\/]*)'\]) && Regexp.last_match(1))&.underscore || context
             width   = (xpath =~ %r(Width\[@type='([^\/]*)'\]) && Regexp.last_match(1)) || width
             :"calendars.gregorian.#{kind}s.#{context}.#{width}"
           end
@@ -103,7 +103,7 @@ module Cldr
 
           def formats(type)
             formats = select(calendar, "#{type}Formats/#{type}FormatLength").each_with_object({}) do |node, result|
-              key = node.attribute("type").value.to_sym
+              key = node.attribute("type").value.underscore.to_sym
               result[key] = pattern(node, type)
             end
             if (default = default_format(type))
@@ -138,7 +138,7 @@ module Cldr
           # That probably means this `fields` method should be moved up to the parent as well.
           def fields
             select("dates/fields/field").each_with_object({}) do |node, result|
-              key  = node.attribute("type").value.to_sym
+              key  = node.attribute("type").value.underscore.gsub(/dayperiod/, "day_period").to_sym
               name = node.xpath("displayName").first
               result[key] = name.content if name
             end

--- a/lib/cldr/export/data/context_transforms.rb
+++ b/lib/cldr/export/data/context_transforms.rb
@@ -13,9 +13,9 @@ module Cldr
 
         def context_transforms
           @context_transforms ||= select("contextTransforms/contextTransformUsage").each_with_object({}) do |usage_node, result|
-            usage_type = usage_node.attribute("type").value.to_sym
+            usage_type = usage_node.attribute("type").value.underscore.to_sym
             result[usage_type] = usage_node.xpath("contextTransform").each_with_object({}) do |transform_node, result|
-              transform_type = transform_node.attribute("type").value.to_sym
+              transform_type = transform_node.attribute("type").value.underscore.to_sym
               result[transform_type] = transform_node.content
             end
           end

--- a/lib/cldr/export/data/context_transforms.rb
+++ b/lib/cldr/export/data/context_transforms.rb
@@ -15,8 +15,9 @@ module Cldr
           @context_transforms ||= select("contextTransforms/contextTransformUsage").each_with_object({}) do |usage_node, result|
             usage_type = usage_node.attribute("type").value.underscore.to_sym
             result[usage_type] = usage_node.xpath("contextTransform").each_with_object({}) do |transform_node, result|
-              transform_type = transform_node.attribute("type").value.underscore.to_sym
-              result[transform_type] = transform_node.content
+              context_type = transform_node.attribute("type").value.underscore.to_sym
+              transform_type = transform_node.content.underscore.gsub(/firstword/, "first_word")
+              result[context_type] = transform_type
             end
           end
         end

--- a/lib/cldr/export/data/fields.rb
+++ b/lib/cldr/export/data/fields.rb
@@ -14,7 +14,7 @@ module Cldr
 
         def fields
           select("dates/fields/field").each_with_object({}) do |field_node, ret|
-            type = field_node.attribute("type").value.to_sym
+            type = field_node.attribute("type").value.underscore.to_sym
             ret[type] = field(field_node)
           end
         end
@@ -65,7 +65,7 @@ module Cldr
           match = xpath.match(%r{^\.\./field\[@type='([^']*)'\]$})
           raise StandardError, "Didn't find expected data in alias path attribute: #{xpath}" unless match
 
-          type = match[1]
+          type = match[1].underscore
           :"fields.#{type}"
         end
       end

--- a/lib/cldr/export/data/lists.rb
+++ b/lib/cldr/export/data/lists.rb
@@ -15,7 +15,7 @@ module Cldr
         def lists
           select("listPatterns/listPattern").each_with_object({}) do |list_pattern, list_pattern_ret|
             pattern_type = if (attribute = list_pattern.attribute("type"))
-              attribute.value.to_sym
+              attribute.value.underscore.to_sym
             else
               :default
             end
@@ -44,7 +44,7 @@ module Cldr
           match = xpath.match(%r{^\.\./listPattern\[@type='([^']*)'\]$})
           raise StandardError, "Didn't find expected data in alias path attribute: #{xpath}" unless match
 
-          type = match[1]
+          type = match[1].underscore
           :"lists.#{type}"
         end
       end

--- a/lib/cldr/export/data/segments_root.rb
+++ b/lib/cldr/export/data/segments_root.rb
@@ -14,7 +14,7 @@ module Cldr
 
         def segmentations
           doc.xpath("ldml/segmentations/segmentation").each_with_object({}) do |seg, ret|
-            type = seg.attribute("type").value
+            type = seg.attribute("type").value.underscore.to_sym
             ret[type] = segmentation(seg)
           end
         end

--- a/lib/cldr/export/data/units.rb
+++ b/lib/cldr/export/data/units.rb
@@ -8,8 +8,8 @@ module Cldr
           super
           update(
             units: {
-              durationUnit: duration_unit,
-              unitLength: unit_length,
+              duration_unit: duration_unit,
+              unit_length: unit_length,
             },
           )
           deep_sort!
@@ -19,7 +19,7 @@ module Cldr
 
         def unit_length
           select("units/unitLength").each_with_object({}) do |node, result|
-            result[node.attribute("type").value.to_sym] = units(node)
+            result[node.attribute("type").value.underscore.to_sym] = units(node)
           end
         end
 
@@ -28,7 +28,7 @@ module Cldr
           return units_xpath_to_key(aliased.attribute("path").value) if aliased
 
           node.xpath("unit").each_with_object({}) do |node, result|
-            result[node.attribute("type").value.to_sym] = unit(node)
+            result[node.attribute("type").value.underscore.to_sym] = unit(node)
           end
         end
 
@@ -48,7 +48,7 @@ module Cldr
 
         def duration_unit
           select("units/durationUnit").each_with_object({}) do |node, result|
-            result[node.attribute("type").value.to_sym] = node.xpath("durationUnitPattern").first.content
+            result[node.attribute("type").value.underscore.to_sym] = node.xpath("durationUnitPattern").first.content
           end
         end
 
@@ -56,16 +56,16 @@ module Cldr
           match = xpath.match(%r{^\.\./unitLength\[@type='([^']*)'\]$})
           raise StandardError, "Didn't find expected data in alias path attribute: #{xpath}" unless match
 
-          type = match[1]
-          :"units.unitLength.#{type}"
+          type = match[1].underscore
+          :"units.unit_length.#{type}"
         end
 
         def unit_xpath_to_key(xpath)
           match = xpath.match(%r{^\.\./unit\[@type='([^']*)'\]$})
           raise StandardError, "Didn't find expected data in alias path attribute: #{xpath}" unless match
 
-          type = match[1]
-          :"units.unitLength.short.#{type}"
+          type = match[1].underscore
+          :"units.unit_length.short.#{type}"
         end
       end
     end

--- a/lib/cldr/export/deep_validate_keys.rb
+++ b/lib/cldr/export/deep_validate_keys.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+class DeepValidateKeys
+  class << self
+    # Keys must be in snake_case, unless specifically exempted.
+    def validate(hash, component, key_path = [])
+      hash.each do |key, value|
+        full_path = key_path + [key]
+        raise ArgumentError, "Invalid key: #{full_path} in #{component}" unless key.to_s == key.to_s.underscore ||
+          SNAKE_CASE_EXCEPTIONS.fetch(component, []).any? { |exception| paths_match(exception, full_path) }
+
+        validate(value, component, full_path) if value.is_a?(Hash)
+      end
+    end
+
+    private
+
+    SNAKE_CASE_EXCEPTIONS = {
+      Aliases: [
+        ["aliases", "language", "."],
+        ["aliases", "territory", "."],
+      ],
+      Calendars: [["calendars", "gregorian", "additional_formats", "."]],
+      Currencies: [["currencies", "."]],
+      CountryCodes: [["country_codes", "."]],
+      CurrencyDigitsAndRounding: [["."]],
+      Fields: [["*", "relative", "."]],
+      Languages: [["languages", "."]],
+      LikelySubtags: [["subtags", "."]],
+      Metazones: [
+        ["primaryzones", "."],
+        ["timezones", "."],
+      ],
+      RegionCurrencies: [["region_currencies", "."]],
+      ParentLocales: [["."]],
+      Subdivisions: [["subdivisions", "."]],
+      Territories: [["territories", "."]],
+      TerritoriesContainment: [["territories", "."]],
+      Timezones: [
+        ["metazones", "."],
+        ["timezones", "."],
+      ],
+      WindowsZones: [
+        ["."],
+        [".", "."],
+      ],
+    }
+
+    def paths_match(pattern, key)
+      raise NotImplementedError, "Multiple * in pattern is unsupported" if pattern.count { |element| element == "*" } > 1
+
+      pattern_index = 0
+      key_index = 0
+
+      while pattern_index < pattern.length
+        if pattern[pattern_index] == "*"
+          pattern_index += 1
+          return true if pattern_index == pattern.length # "*" at the end of a pattern matches everything
+
+          last_match = key.rindex(pattern[pattern_index]) # "*" is greedy, so we need to find the last match
+          return false if last_match.nil?
+
+          key_index = last_match
+        elsif !(pattern[pattern_index] == key[key_index] || (pattern[pattern_index] == "." && key_index < key.length))
+          return false
+        else
+          pattern_index += 1
+          key_index += 1
+        end
+      end
+
+      return false unless key_index == key.length
+
+      true
+    end
+  end
+end

--- a/lib/cldr/export/yaml.rb
+++ b/lib/cldr/export/yaml.rb
@@ -29,6 +29,8 @@ module Cldr
             raise "#{component} data for #{locale} is not sorted." unless sorted_data.to_s == data.to_s || UNSORTED_COMPONENTS.include?(component)
           end
 
+          DeepValidateKeys.validate(data, component)
+
           data = { locale.to_s => data } unless locale.nil?
         end
         data

--- a/lib/cldr/format/date.rb
+++ b/lib/cldr/format/date.rb
@@ -64,12 +64,12 @@ module Cldr
           quarter.to_s.rjust(length, "0")
         when 3
           raise NotImplementedError, 'not yet implemented (requires cldr\'s "multiple inheritance")'
-          # calendar[:quarters][:'stand-alone'][:abbreviated][key]
+          # calendar[:quarters][:stand_alone][:abbreviated][key]
         when 4
           raise NotImplementedError, 'not yet implemented (requires cldr\'s "multiple inheritance")'
-          # calendar[:quarters][:'stand-alone'][:wide][key]
+          # calendar[:quarters][:stand_alone][:wide][key]
         when 5
-          calendar[:quarters][:"stand-alone"][:narrow][quarter]
+          calendar[:quarters][:stand_alone][:narrow][quarter]
         end
       end
 
@@ -99,12 +99,12 @@ module Cldr
           date.month.to_s.rjust(length, "0")
         when 3
           raise NotImplementedError, 'not yet implemented (requires cldr\'s "multiple inheritance")'
-          # calendar[:months][:"stand-alone"][:abbreviated][date.month]
+          # calendar[:months][:stand_alone][:abbreviated][date.month]
         when 4
           raise NotImplementedError, 'not yet implemented (requires cldr\'s "multiple inheritance")'
-          # calendar[:months][:"stand-alone"][:wide][date.month]
+          # calendar[:months][:stand_alone][:wide][date.month]
         when 5
-          calendar[:months][:"stand-alone"][:narrow][date.month]
+          calendar[:months][:stand_alone][:narrow][date.month]
         else
           # raise unknown date format
         end
@@ -129,7 +129,7 @@ module Cldr
         when 4
           calendar[:days][:format][:wide][key]
         when 5
-          calendar[:days][:"stand-alone"][:narrow][key]
+          calendar[:days][:stand_alone][:narrow][key]
         end
       end
 

--- a/ruby-cldr.gemspec
+++ b/ruby-cldr.gemspec
@@ -73,6 +73,7 @@ Gem::Specification.new do |s|
     "lib/cldr/export/data/variables.rb",
     "lib/cldr/export/data/windows_zones.rb",
     "lib/cldr/export/data_file.rb",
+    "lib/cldr/export/deep_validate_keys.rb",
     "lib/cldr/export/ruby.rb",
     "lib/cldr/export/yaml.rb",
     "lib/cldr/format.rb",

--- a/test/export/data/calendars_test.rb
+++ b/test/export/data/calendars_test.rb
@@ -16,7 +16,7 @@ class TestCldrDataCalendars < Test::Unit::TestCase
         narrow: { 1 => "J", 2 => "F", 3 => "M", 4 => "A", 5 => "M", 6 => "J", 7 => "J", 8 => "A", 9 => "S", 10 => "O", 11 => "N", 12 => "D" },
         wide: { 1 => "Januar", 2 => "Februar", 3 => "März", 4 => "April", 5 => "Mai", 6 => "Juni", 7 => "Juli", 8 => "August", 9 => "September", 10 => "Oktober", 11 => "November", 12 => "Dezember" },
       },
-      "stand-alone": {
+      stand_alone: {
         abbreviated: { 1 => "Jan", 2 => "Feb", 3 => "Mär", 4 => "Apr", 5 => "Mai", 6 => "Jun", 7 => "Jul", 8 => "Aug", 9 => "Sep", 10 => "Okt", 11 => "Nov", 12 => "Dez" },
         narrow: { 1 => "J", 2 => "F", 3 => "M", 4 => "A", 5 => "M", 6 => "J", 7 => "J", 8 => "A", 9 => "S", 10 => "O", 11 => "N", 12 => "D" },
         wide: { 1 => "Januar", 2 => "Februar", 3 => "März", 4 => "April", 5 => "Mai", 6 => "Juni", 7 => "Juli", 8 => "August", 9 => "September", 10 => "Oktober", 11 => "November", 12 => "Dezember" },
@@ -31,7 +31,7 @@ class TestCldrDataCalendars < Test::Unit::TestCase
         abbreviated: { 1 => "Jan", 2 => "Feb", 3 => "Mar", 4 => "Apr", 5 => "May", 6 => "Jun", 7 => "Jul", 8 => "Aug", 9 => "Sep", 10 => "Oct", 11 => "Nov", 12 => "Dec" },
         wide: { 1 => "January", 2 => "February", 3 => "March", 4 => "April", 5 => "May", 6 => "June", 7 => "July", 8 => "August", 9 => "September", 10 => "October", 11 => "November", 12 => "December" },
       },
-      "stand-alone": {
+      stand_alone: {
         narrow: { 1 => "J", 2 => "F", 3 => "M", 4 => "A", 5 => "M", 6 => "J", 7 => "J", 8 => "A", 9 => "S", 10 => "O", 11 => "N", 12 => "D" },
       },
     }
@@ -42,10 +42,10 @@ class TestCldrDataCalendars < Test::Unit::TestCase
     months = {
       format: {
         abbreviated: { 1 => "Jan", 2 => "Feb", 3 => "Mar", 4 => "Apr", 5 => "May", 6 => "Jun", 7 => "Jul", 8 => "Aug", 9 => "Sep", 10 => "Oct", 11 => "Nov", 12 => "Dec" },
-        narrow: :"calendars.gregorian.months.stand-alone.narrow",
+        narrow: :"calendars.gregorian.months.stand_alone.narrow",
         wide: { 1 => "January", 2 => "February", 3 => "March", 4 => "April", 5 => "May", 6 => "June", 7 => "July", 8 => "August", 9 => "September", 10 => "October", 11 => "November", 12 => "December" },
       },
-      "stand-alone": {
+      stand_alone: {
         abbreviated: :"calendars.gregorian.months.format.abbreviated",
         narrow: { 1 => "J", 2 => "F", 3 => "M", 4 => "A", 5 => "M", 6 => "J", 7 => "J", 8 => "A", 9 => "S", 10 => "O", 11 => "N", 12 => "D" },
         wide: :"calendars.gregorian.months.format.wide",
@@ -62,7 +62,7 @@ class TestCldrDataCalendars < Test::Unit::TestCase
         narrow: { sun: "S", mon: "M", tue: "D", wed: "M", thu: "D", fri: "F", sat: "S" },
         short: { sun: "So.", mon: "Mo.", tue: "Di.", wed: "Mi.", thu: "Do.", fri: "Fr.", sat: "Sa." },
       },
-      "stand-alone": {
+      stand_alone: {
         abbreviated: { sun: "So", mon: "Mo", tue: "Di", wed: "Mi", thu: "Do", fri: "Fr", sat: "Sa" },
         narrow: { sun: "S", mon: "M", tue: "D", wed: "M", thu: "D", fri: "F", sat: "S" },
         short: { sun: "So.", mon: "Mo.", tue: "Di.", wed: "Mi.", thu: "Do.", fri: "Fr.", sat: "Sa." },
@@ -79,7 +79,7 @@ class TestCldrDataCalendars < Test::Unit::TestCase
         narrow: { 1 => "1", 2 => "2", 3 => "3", 4 => "4" },
         abbreviated: { 1 => "Q1", 2 => "Q2", 3 => "Q3", 4 => "Q4" },
       },
-      "stand-alone": {
+      stand_alone: {
         abbreviated: { 1 => "Q1", 2 => "Q2", 3 => "Q3", 4 => "Q4" },
         narrow: { 1 => "1", 2 => "2", 3 => "3", 4 => "4" },
         wide: { 1 => "1. Quartal", 2 => "2. Quartal", 3 => "3. Quartal", 4 => "4. Quartal" },
@@ -157,57 +157,57 @@ class TestCldrDataCalendars < Test::Unit::TestCase
   test "calendars fields :de" do
     fields = {
       day: "Tag",
-      "day-narrow": "Tag",
-      "day-short": "Tag",
-      dayOfYear: "Tag des Jahres",
-      "dayOfYear-narrow": "T/J",
-      "dayOfYear-short": "Tag des Jahres",
-      dayperiod: "Tageshälfte",
-      "dayperiod-narrow": "Tagesh.",
-      "dayperiod-short": "Tageshälfte",
+      day_narrow: "Tag",
+      day_short: "Tag",
+      day_of_year: "Tag des Jahres",
+      day_of_year_narrow: "T/J",
+      day_of_year_short: "Tag des Jahres",
+      day_period: "Tageshälfte",
+      day_period_narrow: "Tagesh.",
+      day_period_short: "Tageshälfte",
       era: "Epoche",
-      "era-narrow": "E",
-      "era-short": "Epoche",
+      era_narrow: "E",
+      era_short: "Epoche",
       hour: "Stunde",
-      "hour-narrow": "Std.",
-      "hour-short": "Std.",
+      hour_narrow: "Std.",
+      hour_short: "Std.",
       minute: "Minute",
-      "minute-narrow": "Min.",
-      "minute-short": "Min.",
+      minute_narrow: "Min.",
+      minute_short: "Min.",
       month: "Monat",
-      "month-narrow": "M",
-      "month-short": "Monat",
+      month_narrow: "M",
+      month_short: "Monat",
       quarter: "Quartal",
-      "quarter-narrow": "Q",
-      "quarter-short": "Quart.",
+      quarter_narrow: "Q",
+      quarter_short: "Quart.",
       second: "Sekunde",
-      "second-narrow": "Sek.",
-      "second-short": "Sek.",
+      second_narrow: "Sek.",
+      second_short: "Sek.",
       week: "Woche",
-      "week-narrow": "W",
-      "week-short": "Woche",
-      weekOfMonth: "Woche des Monats",
-      "weekOfMonth-narrow": "Wo. des Monats",
-      "weekOfMonth-short": "W/M",
+      week_narrow: "W",
+      week_short: "Woche",
+      week_of_month: "Woche des Monats",
+      week_of_month_narrow: "Wo. des Monats",
+      week_of_month_short: "W/M",
       weekday: "Wochentag",
-      "weekday-narrow": "Wochent.",
-      "weekday-short": "Wochentag",
-      weekdayOfMonth: "Wochentag",
-      "weekdayOfMonth-narrow": "WT",
-      "weekdayOfMonth-short": "Wochentag",
+      weekday_narrow: "Wochent.",
+      weekday_short: "Wochentag",
+      weekday_of_month: "Wochentag",
+      weekday_of_month_narrow: "WT",
+      weekday_of_month_short: "Wochentag",
       year: "Jahr",
-      "year-narrow": "J",
-      "year-short": "Jahr",
+      year_narrow: "J",
+      year_short: "Jahr",
       zone: "Zeitzone",
-      "zone-narrow": "Zeitz.",
-      "zone-short": "Zeitzone",
+      zone_narrow: "Zeitz.",
+      zone_short: "Zeitzone",
     }
     assert_equal fields, gregorian[:fields]
   end
 
   test "merged calendars for de-AT contains all date format and stand-alone name types" do
     assert_equal ["abbreviated", "narrow", "wide"], gregorian(merged: true)[:months][:format].keys.map(&:to_s).sort
-    assert_equal ["abbreviated", "narrow", "wide"], gregorian(merged: true)[:months][:"stand-alone"].keys.map(&:to_s).sort
+    assert_equal ["abbreviated", "narrow", "wide"], gregorian(merged: true)[:months][:stand_alone].keys.map(&:to_s).sort
   end
 
   test "Gregorian eras for :root contains the expected alias nodes" do

--- a/test/export/data/fields_test.rb
+++ b/test/export/data/fields_test.rb
@@ -6,8 +6,8 @@ require File.expand_path(File.join(File.dirname(__FILE__) + "/../../test_helper"
 class TestCldrDataFields < Test::Unit::TestCase
   test "Alias nodes are exported as paths to their targets" do
     data = Cldr::Export::Data::Fields.new(:root)
-    path = data.dig(:fields, :"day-narrow")
-    assert_equal :"fields.day-short", path
+    path = data.dig(:fields, :day_narrow)
+    assert_equal :"fields.day_short", path
 
     path = data.dig(*split_path_string(path))
     assert_equal :"fields.day", path

--- a/test/export/data/lists_test.rb
+++ b/test/export/data/lists_test.rb
@@ -6,8 +6,8 @@ require File.expand_path(File.join(File.dirname(__FILE__) + "/../../test_helper"
 class TestCldrDataLists < Test::Unit::TestCase
   test "Alias nodes are exported as paths to their targets" do
     data = Cldr::Export::Data::Lists.new(:root)
-    path = data.dig(:lists, :"or-narrow")
-    assert_equal :"lists.or-short", path
+    path = data.dig(:lists, :or_narrow)
+    assert_equal :"lists.or_short", path
 
     path = data.dig(*split_path_string(path))
     assert_equal :"lists.or", path

--- a/test/export/data/units_test.rb
+++ b/test/export/data/units_test.rb
@@ -14,22 +14,22 @@ class TestCldrDataUnits < Test::Unit::TestCase
       minute: { one: "{0} Minute",  other: "{0} Minuten" },
       second: { one: "{0} Sekunde", other: "{0} Sekunden" },
     }
-    data = Cldr::Export::Data::Units.new(:de)[:units][:unitLength][:long]
+    data = Cldr::Export::Data::Units.new(:de)[:units][:unit_length][:long]
 
     assert_operator data.keys.count, :>=, 46
-    assert_equal units[:day],    data[:"duration-day"]
-    assert_equal units[:week],   data[:"duration-week"]
-    assert_equal units[:month],  data[:"duration-month"]
-    assert_equal units[:year],   data[:"duration-year"]
-    assert_equal units[:hour],   data[:"duration-hour"]
-    assert_equal units[:minute], data[:"duration-minute"]
-    assert_equal units[:second], data[:"duration-second"]
+    assert_equal units[:day],    data[:duration_day]
+    assert_equal units[:week],   data[:duration_week]
+    assert_equal units[:month],  data[:duration_month]
+    assert_equal units[:year],   data[:duration_year]
+    assert_equal units[:hour],   data[:duration_hour]
+    assert_equal units[:minute], data[:duration_minute]
+    assert_equal units[:second], data[:duration_second]
   end
 
   test "Alias nodes are exported as paths to their targets" do
     data = Cldr::Export::Data::Units.new(:root)
-    path = data.dig(:units, :unitLength, :short, :"duration-week-person")
-    assert_equal :"units.unitLength.short.duration-week", path
+    path = data.dig(:units, :unit_length, :short, :duration_week_person)
+    assert_equal :"units.unit_length.short.duration_week", path
 
     duration = data.dig(*split_path_string(path))
     assert_not_nil duration

--- a/test/export/deep_validate_keys_test.rb
+++ b/test/export/deep_validate_keys_test.rb
@@ -1,0 +1,49 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+require File.expand_path(File.join(File.dirname(__FILE__) + "/../test_helper"))
+require File.expand_path(File.join(File.dirname(__FILE__) + "/../../lib/cldr/export/deep_validate_keys"))
+
+class TestDeepValidateKeys < Test::Unit::TestCase
+  test "#paths_match with empty pattern matches only empty key" do
+    assert DeepValidateKeys.send(:paths_match, [], [])
+    refute DeepValidateKeys.send(:paths_match, [], ["foo", "bar", "baz", "qux"])
+  end
+
+  test "#paths_match matches with exact match" do
+    assert DeepValidateKeys.send(:paths_match, ["foo", "bar"], ["foo", "bar"])
+
+    refute DeepValidateKeys.send(:paths_match, ["foo"], ["foo", "bar", "baz", "qux"])
+    refute DeepValidateKeys.send(:paths_match, ["foo"], ["bar", "baz", "qux"])
+    refute DeepValidateKeys.send(:paths_match, ["foo", "bar"], ["foo"])
+    refute DeepValidateKeys.send(:paths_match, ["foo", "baz"], ["foo", "bar", "baz", "qux"])
+  end
+
+  test "#paths_match with . matches single element" do
+    assert DeepValidateKeys.send(:paths_match, ["foo", ".", "baz"], ["foo", "bar", "baz"])
+    assert DeepValidateKeys.send(:paths_match, ["foo", ".", ".", "qux"], ["foo", "bar", "baz", "qux"])
+    assert DeepValidateKeys.send(:paths_match, ["."], ["foo"])
+    assert DeepValidateKeys.send(:paths_match, [".", "bar"], ["foo", "bar"])
+
+    refute DeepValidateKeys.send(:paths_match, ["."], [])
+  end
+
+  test "#paths_match with trailing * matches anything after the star" do
+    assert DeepValidateKeys.send(:paths_match, ["foo", "*"], ["foo", "bar", "baz", "qux"])
+    assert DeepValidateKeys.send(:paths_match, ["*"], [])
+    assert DeepValidateKeys.send(:paths_match, ["*"], ["foo", "bar", "baz", "qux"])
+  end
+
+  test "#paths_match with * greedy matches up to the last match of the next element" do
+    assert DeepValidateKeys.send(:paths_match, ["foo", "*", "baz", "quxx"], ["foo", "bar", "baz", "qux", "baz", "quxx"])
+
+    refute DeepValidateKeys.send(:paths_match, ["foo", "*", "baz", "quxx"], ["foo", "bar", "baz", "qux"])
+  end
+
+  test "#paths_match raise when given a pattern with multiple *" do
+    exc = assert_raises(NotImplementedError) do
+      DeepValidateKeys.send(:paths_match, ["foo", "*", "baz", "*"], ["foo", "bar", "baz", "qux", "baz", "quxx"])
+    end
+    assert_equal "Multiple * in pattern is unsupported", exc.message
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

CLDR `type` attributes use an aesthetically gross mix of camelCase, snake_case, and kebab-case.
While exporting the data, let's standardize on `snake_case`.

### What approach did you choose and why?

Added `.underscore` in the places that needed it.

Exceptions are made for external identifiers (e.g. ISO codes)

I then added some code (`DeepKeyValidate#validate`) to verify that all keys being exported are snake_case, to make sure that we can't miss any cases.

### What should reviewers focus on?

Is this actually a good idea? It's really just aesthetics/consistency that we're going for with these changes, and that brings us out of sync with CLDR, since we aren't accepting their identifiers.

Further, `underscore` doesn't help with identifiers that:

* Are strangely combined in CLDR (e.g., `dayperiod` instead of `day_period`. I fixed this one specifically, but there are possibly others)
* end in a number (e.g., `address1` instead of `address_1`) 🤷 

### The impact of these changes

- My eyes hurt less looking at the exported files. More consistent output.
- They seem more idiomatic in the Ruby environment.

Obviously, this is a breaking change for those who are using the old keys. We're pre-1.0, so can do pretty much do whatever we want (and have been).

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
