### PR TITLE
Add `WeekData` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Export `<contextTransforms>` data, [#206](https://github.com/ruby-i18n/ruby-cldr/pull/206)
 - `Numbers` component now outputs data from all number systems, [#189](https://github.com/ruby-i18n/ruby-cldr/pull/189)
 - Use `snake_case` for key names unless they are an external identifier, [#207](https://github.com/ruby-i18n/ruby-cldr/pull/207)
+- Add `WeekData` component, [#229](https://github.com/ruby-i18n/ruby-cldr/pull/229)
 
 ---
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,9 @@ GEM
     builder (3.2.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
+    debug (1.7.1)
+      irb (>= 1.5.0)
+      reline (>= 0.3.1)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     faraday (0.9.2)
@@ -23,6 +26,9 @@ GEM
     highline (2.0.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    io-console (0.6.0)
+    irb (1.6.2)
+      reline (>= 0.3.0)
     jeweler (2.3.9)
       builder
       bundler
@@ -71,6 +77,8 @@ GEM
     rchardet (1.8.0)
     rdoc (6.3.3)
     regexp_parser (2.6.1)
+    reline (0.3.2)
+      io-console (~> 0.5)
     rexml (3.2.5)
     rubocop (1.42.0)
       json (~> 2.3)
@@ -107,6 +115,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  debug
   i18n
   jeweler
   nokogiri

--- a/lib/cldr/export.rb
+++ b/lib/cldr/export.rb
@@ -37,6 +37,7 @@ module Cldr
       :TerritoriesContainment,
       :Transforms,
       :Variables,
+      :WeekData,
       :WindowsZones,
     ].freeze
 

--- a/lib/cldr/export/data.rb
+++ b/lib/cldr/export/data.rb
@@ -36,6 +36,7 @@ module Cldr
       autoload :Timezones,                 "cldr/export/data/timezones"
       autoload :Units,                     "cldr/export/data/units"
       autoload :Variables,                 "cldr/export/data/variables"
+      autoload :WeekData,                  "cldr/export/data/week_data"
       autoload :WindowsZones,              "cldr/export/data/windows_zones"
       autoload :Transforms,                "cldr/export/data/transforms"
 

--- a/lib/cldr/export/data/week_data.rb
+++ b/lib/cldr/export/data/week_data.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Cldr
+  module Export
+    module Data
+      class WeekData < Base
+        def initialize(*)
+          super(nil)
+          update(first_day: first_day)
+          deep_sort!
+        end
+
+        def first_day
+          @week_data ||= doc.xpath("supplementalData/weekData/firstDay").filter_map do |node|
+            alt = node.attribute("alt")
+            next if alt
+
+            day = node.attribute("day").value
+            territories = node.attribute("territories").value.split(" ")
+            [day, territories]
+          end.to_h
+        end
+      end
+    end
+  end
+end

--- a/test/export/data/week_data_test.rb
+++ b/test/export/data/week_data_test.rb
@@ -1,0 +1,11 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+require File.expand_path(File.join(File.dirname(__FILE__) + "/../../test_helper"))
+
+class TestCldrDataWeekData < Test::Unit::TestCase
+  test "first day data" do
+    first_day = Cldr::Export::Data::WeekData.new[:first_day]
+    assert_equal(["MV"], first_day["fri"])
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

I had a use for `firstDay` data, so I've added a `WeekData` component.

### What approach did you choose and why?

Straightforward extraction of the data.

### What should reviewers focus on?

🤷 

### The impact of these changes

Users will have access to `firstDay` data.
There's a component available to expand to include the [other `weekData`](https://www.unicode.org/reports/tr35/tr35-dates.html#Week_Data).

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
