### PR TITLE
Sort after merging

### DIFF
--- a/lib/cldr/export.rb
+++ b/lib/cldr/export.rb
@@ -124,7 +124,7 @@ module Cldr
         locales_to_merge(locale, component, options).inject({}) do |result, locale|
           data = Data.const_get(component.to_s).new(locale)
           if data
-            data.is_a?(Hash) ? data.deep_merge(result) : data
+            data.is_a?(Hash) ? data.deep_merge(result).deep_sort : data
           else
             result
           end


### PR DESCRIPTION
Exporting `pt-PT`with the `--merge` option raises an exception:

```
$ bundle exec thor cldr:export --locales pt-PT --merge --components Languages 
/ruby-cldr/lib/cldr/export/yaml.rb:29:in `format': Languages data for pt-PT is not sorted. (RuntimeError)
    from /ruby-cldr/lib/cldr/export/yaml.rb:10:in `export'
    from /ruby-cldr/lib/cldr/export.rb:96:in `block (2 levels) in export'
    from /ruby-cldr/lib/cldr/export.rb:95:in `each'
    from /ruby-cldr/lib/cldr/export.rb:95:in `block in export'
```
