### PR TITLE
Check if block is given

### DIFF
--- a/lib/cldr/download.rb
+++ b/lib/cldr/download.rb
@@ -23,7 +23,7 @@ module Cldr
               path = File.join(target, entry.name)
               FileUtils.mkdir_p(File.dirname(path))
               file.extract(entry, path)
-              yield path
+              yield path if block_given?
             end
           end
         end


### PR DESCRIPTION
Allow calling `Cldr::Download.download` without a block if we don't care about displaying download progress.