### PR TITLE
Fix list parameter parsing

### DIFF
--- a/lib/cldr/thor.rb
+++ b/lib/cldr/thor.rb
@@ -37,8 +37,8 @@ module Cldr
 
     desc "export [--locales=de fr-FR en-ZA] [--components=Numbers Plurals] [--target=#{Cldr::Export::DEFAULT_TARGET}] [--merge/--no-merge]",
       "Export CLDR data by locales and components to target dir"
-    option :locales, aliases: [:l], type: :array, banner: "de fr-FR en-ZA", enum: Cldr::Export::Data::RAW_DATA.locales
-    option :components, aliases: [:c], type: :array, banner: "Numbers Plurals", enum: Cldr::Export::Data.components
+    option :locales, aliases: [:l], type: :array, banner: "de fr-FR en-ZA", enum: Cldr::Export::Data::RAW_DATA.locales.map(&:to_s)
+    option :components, aliases: [:c], type: :array, banner: "Numbers Plurals", enum: Cldr::Export::Data.components.map(&:to_s)
     option :target, aliases: [:t], type: :string, default: Cldr::Export::DEFAULT_TARGET, banner: Cldr::Export::DEFAULT_TARGET
     option :draft_status,
       aliases: [:d],
@@ -53,17 +53,11 @@ module Cldr
 
       formatted_options = options.dup.symbolize_keys
 
-      # We do this validation, since thor doesn't
-      # https://github.com/rails/thor/issues/783
       if formatted_options.key?(:locales)
-        formatted_options[:locales] = formatted_options[:locales].map(&:to_sym) if formatted_options.key?(:locales)
-        unknown_locales = formatted_options[:locales] - Cldr::Export::Data::RAW_DATA.locales
-        raise ArgumentError, "Unknown locales: #{unknown_locales.map { |l| "`#{l}`" }.join(", ")}" unless unknown_locales.empty?
+        formatted_options[:locales] = formatted_options[:locales].map(&:to_sym)
       end
       if formatted_options.key?(:components)
-        formatted_options[:components] = formatted_options[:components].map(&:to_sym) if formatted_options.key?(:components)
-        unknown_components = formatted_options[:components] - Cldr::Export::Data.components
-        raise ArgumentError, "Unknown components: #{unknown_components.join(", ")}" unless unknown_components.empty?
+        formatted_options[:components] = formatted_options[:components].map(&:to_sym)
       end
 
       if formatted_options.key?(:draft_status)

--- a/ruby-cldr.gemspec
+++ b/ruby-cldr.gemspec
@@ -147,7 +147,7 @@ Gem::Specification.new do |s|
     s.add_runtime_dependency("nokogiri", [">= 0"])
     s.add_runtime_dependency("psych", [">= 4.0.0"])
     s.add_runtime_dependency("rubyzip", [">= 0"])
-    s.add_runtime_dependency("thor", [">= 0"])
+    s.add_runtime_dependency("thor", [">= 1.3.0"])
     s.add_development_dependency("jeweler", [">= 0"])
     s.add_development_dependency("pry", [">= 0"])
     s.add_development_dependency("pry-nav", [">= 0"])
@@ -165,6 +165,6 @@ Gem::Specification.new do |s|
     s.add_dependency("ruby-lsp", [">= 0"])
     s.add_dependency("rubyzip", [">= 0"])
     s.add_dependency("test-unit", [">= 0"])
-    s.add_dependency("thor", [">= 0"])
+    s.add_dependency("thor", [">= 1.3.0"])
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

```
✗ thor cldr:export --components Plurals --target=./data
Expected all values of '--components' to be one of Aliases, Calendars, Characters, ContextTransforms, CountryCodes, Currencies, 
CurrencyDigitsAndRounding, Delimiters, Fields, Languages, Layout, LikelySubtags, 
Lists, Metazones, NumberingSystems, Numbers, ParentLocales, PluralRules, Plurals, 
Rbnf, RbnfRoot, RegionCurrencies, RegionValidity, SegmentsRoot, Subdivisions, 
Territories, TerritoriesContainment, Timezones, Transforms, Units, Variables, 
WeekData, WindowsZones; got Plurals
```

Broke in thor v1.3.0, when the values of enum began being validated. 
`enum` is expected to be Strings, but we were passing in Symbols.

https://github.com/rails/thor/pull/784

### What approach did you choose and why?

1. Fixed the Symbol/String confusion.
2. Removed the extra validation we were doing
3. Bumped the minimum version of Thor to 1.3.0.
    * So people aren't using an older version without the validation

### What should reviewers focus on?

🤷 

### The impact of these changes

These list/enum parameters will work again

### Testing

```
✗ thor cldr:export --components Plurals --target=./data
```


### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
