### PR TITLE
Test against Ruby 3.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["3.0", "3.1", "3.2", "3.3"]
+        ruby-version: ["3.1", "3.2", "3.3"]
         cldr-version: [41]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["3.0", "3.1", "3.2"]
+        ruby-version: ["3.0", "3.1", "3.2", "3.3"]
         cldr-version: [41]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Use `snake_case` for key names unless they are an external identifier, [#207](https://github.com/ruby-i18n/ruby-cldr/pull/207)
 - Add `WeekData` component, [#229](https://github.com/ruby-i18n/ruby-cldr/pull/229)
 - Drop support for Ruby 2, [#265](https://github.com/ruby-i18n/ruby-cldr/pull/265)
+- Drop support for Ruby 3.0, [#268](https://github.com/ruby-i18n/ruby-cldr/pull/268)
 
 ---
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,12 +3,14 @@ GEM
   specs:
     addressable (2.4.0)
     ast (2.4.2)
-    builder (3.2.3)
+    base64 (0.2.0)
+    bigdecimal (3.1.8)
+    builder (3.3.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.4)
-    debug (1.8.0)
-      irb (>= 1.5.0)
-      reline (>= 0.3.1)
+    debug (1.9.2)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     faraday (0.9.2)
@@ -22,13 +24,15 @@ GEM
       hashie (>= 3.4)
       mime-types (>= 1.16, < 3.0)
       oauth2 (~> 1.0)
-    hashie (3.6.0)
-    highline (2.0.1)
+    hashie (5.0.0)
+    highline (3.1.1)
+      reline
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    io-console (0.6.0)
-    irb (1.6.4)
-      reline (>= 0.3.0)
+    io-console (0.7.2)
+    irb (1.14.1)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     jeweler (2.3.9)
       builder
       bundler
@@ -41,19 +45,30 @@ GEM
       rdoc
       semver2
     json (2.8.2)
-    jwt (2.1.0)
+    jwt (2.9.3)
+      base64
     language_server-protocol (3.17.0.3)
-    method_source (1.0.0)
+    logger (1.6.1)
+    method_source (1.1.0)
     mime-types (2.99.3)
-    mini_portile2 (2.8.8)
-    multi_json (1.13.1)
-    multi_xml (0.6.0)
-    multipart-post (2.0.0)
-    nokogiri (1.16.7)
-      mini_portile2 (~> 2.8.2)
+    multi_json (1.15.0)
+    multi_xml (0.7.1)
+      bigdecimal (~> 3.1)
+    multipart-post (2.4.1)
+    nokogiri (1.16.7-aarch64-linux)
       racc (~> 1.4)
-    oauth2 (1.4.1)
-      faraday (>= 0.8, < 0.16.0)
+    nokogiri (1.16.7-arm-linux)
+      racc (~> 1.4)
+    nokogiri (1.16.7-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.7-x86-linux)
+      racc (~> 1.4)
+    nokogiri (1.16.7-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.7-x86_64-linux)
+      racc (~> 1.4)
+    oauth2 (1.4.8)
+      faraday (>= 0.8, < 3.0)
       jwt (>= 1.0, < 3.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
@@ -62,23 +77,26 @@ GEM
     parser (3.3.6.0)
       ast (~> 2.4.1)
       racc
-    power_assert (2.0.3)
-    prettier_print (1.2.1)
+    power_assert (2.0.4)
+    prism (1.2.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
     pry-nav (1.0.0)
       pry (>= 0.9.10, < 0.15)
-    psych (5.1.0)
+    psych (5.2.0)
       stringio
     racc (1.8.1)
-    rack (2.2.8.1)
+    rack (2.2.10)
     rainbow (3.1.1)
-    rake (13.0.1)
+    rake (13.2.1)
+    rbs (3.6.1)
+      logger
     rchardet (1.8.0)
-    rdoc (6.3.4.1)
+    rdoc (6.8.1)
+      psych (>= 4.0.0)
     regexp_parser (2.9.3)
-    reline (0.3.3)
+    reline (0.5.12)
       io-console (~> 0.5)
     rubocop (1.69.0)
       json (~> 2.3)
@@ -94,27 +112,31 @@ GEM
       parser (>= 3.3.1.0)
     rubocop-shopify (2.15.1)
       rubocop (~> 1.51)
-    ruby-lsp (0.7.3)
+    ruby-lsp (0.22.1)
       language_server-protocol (~> 3.17.0)
-      sorbet-runtime
-      syntax_tree (>= 6.1.1, < 7)
+      prism (>= 1.2, < 2.0)
+      rbs (>= 3, < 4)
+      sorbet-runtime (>= 0.5.10782)
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
     semver2 (3.4.2)
-    sorbet-runtime (0.5.10921)
-    stringio (3.0.5)
-    syntax_tree (6.1.1)
-      prettier_print (>= 1.2.0)
-    test-unit (3.6.1)
+    sorbet-runtime (0.5.11670)
+    stringio (3.1.2)
+    test-unit (3.6.4)
       power_assert
-    thor (1.2.1)
+    thor (1.3.2)
     thread_safe (0.3.6)
     unicode-display_width (3.1.2)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
 
 PLATFORMS
-  ruby
+  aarch64-linux
+  arm-linux
+  arm64-darwin
+  x86-linux
+  x86_64-darwin
+  x86_64-linux
 
 DEPENDENCIES
   debug
@@ -131,4 +153,4 @@ DEPENDENCIES
   thor
 
 BUNDLED WITH
-   2.1.4
+   2.5.23

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ There are still a number of issues that need to be addressed before it can be co
 
 ## Requirements
 
-  * Ruby 3.0+
+  * Ruby 3.1+
   * [Thor](http://whatisthor.com/)
 
 ## Installation


### PR DESCRIPTION
### What are you trying to accomplish?

Enable testing against Ruby 3.3

### What approach did you choose and why?

1. Add Ruby 3.3 in CI.
2. `bundle update` to get past `stringio` build errors
3. Dropped support for EOL Ruby 3.0 (since `multi_xml` has dropped support)

### What should reviewers focus on?

🤷 

### The impact of these changes

Tests will be run against Ruby 3.3

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
