### PR TITLE
Lint with Ruby 3.1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,11 +19,11 @@ jobs:
       - name: Install libyaml
         run: sudo apt-get update -y && sudo apt-get install -y libyaml-dev
 
-      - name: Set up Ruby 3.1
+      - name: Set up Ruby 3.3
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: 3.1
+          ruby-version: 3.3
 
       - name: Lint code
         run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ inherit_gem:
   rubocop-shopify: rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
   UseCache: true
   CacheRootDirectory: tmp/rubocop
   NewCops: enable


### PR DESCRIPTION
### What are you trying to accomplish?

#268 dropped support for 3.0, but I didn't increment the linter's syntax version.

### What approach did you choose and why?

Increment the linter's syntax version.

### What should reviewers focus on?

🤷 

### The impact of these changes

We'll be linting with 3.1 syntax.

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
