### PR TITLE
feat: export locale_display_pattern

### DIFF
--- a/lib/cldr/export/data.rb
+++ b/lib/cldr/export/data.rb
@@ -19,6 +19,7 @@ module Cldr
       autoload :Layout,                    "cldr/export/data/layout"
       autoload :LikelySubtags,             "cldr/export/data/likely_subtags"
       autoload :Lists,                     "cldr/export/data/lists"
+      autoload :LocaleDisplayPattern,      "cldr/export/data/locale_display_pattern"
       autoload :Metazones,                 "cldr/export/data/metazones"
       autoload :NumberingSystems,          "cldr/export/data/numbering_systems"
       autoload :Numbers,                   "cldr/export/data/numbers"

--- a/lib/cldr/export/data/locale_display_pattern.rb
+++ b/lib/cldr/export/data/locale_display_pattern.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Cldr
+  module Export
+    module Data
+      class LocaleDisplayPattern < Base
+        def initialize(locale)
+          super
+          update(locale_display_pattern: locale_display_pattern)
+        end
+
+        private
+
+        def locale_display_pattern
+          @locale_display_pattern ||= select("localeDisplayNames/localeDisplayPattern/*").each_with_object({}) do |node, result|
+            result[node.name.underscore] = node.content
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/export/data/locale_display_pattern_test.rb
+++ b/test/export/data/locale_display_pattern_test.rb
@@ -1,0 +1,18 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+require File.expand_path(File.join(File.dirname(__FILE__) + "/../../test_helper"))
+
+class TestLocaleDisplayPattern < Test::Unit::TestCase
+  test "locale_display_pattern :de" do
+    expected = {
+      "locale_key_type_pattern" => "{0}: {1}",
+      "locale_pattern" => "{0} ({1})",
+      "locale_separator" => "{0}, {1}",
+    }
+
+    actual = Cldr::Export::Data::LocaleDisplayPattern.new(:de)[:locale_display_pattern]
+
+    assert_equal expected, actual
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

While CLDR contains translations of language names for simple locales in the `<languages>` element, complex locales, such as a locale with a region, may not always have a specific translation in every language. For example, `pt-BR` has a specific translation in English to "Brazilian Portuguese", but there is no specific translation for that locale in German.

When a complex locale has no specific translation, CLDR [specifies](https://www.unicode.org/reports/tr35/tr35-73/tr35-general.html#Display_Name_Elements) that we should use the patterns in `<localeDisplayPattern>` to construct a display name out of the parts. The patterns are largely the same for most locales, but there are some slight differences, especially in choice of punctuation characters (half- vs full-width) for Asian languages, and use of spaces, so it's necessary to have separate patterns for each locale.

ruby-cldr doesn't currently export the contents of `<localeDisplayPattern>`, so projects cannot use ruby-cldr to consume these patterns through this library. At my team at Binti, we had to use cldr-json directly to get access to these patterns. I'd like to add support to export these patterns, so projects could use ruby-cldr instead.

...

### What approach did you choose and why?

The approach in this PR is based on `Cldr::Export::Data::Languages` exporter.

It generates a `locale_display_pattern.yml` file with contents like the following:

```yaml
---
de:
  locale_display_pattern:
    locale_key_type_pattern: "{0}: {1}"
    locale_pattern: "{0} ({1})"
    locale_separator: "{0}, {1}"
```

The keys are just the snake_case versions of the element names from CLDR.

...

### What should reviewers focus on?

I think this is pretty straightforward, from a code perspective, but if it would be better to put this data in an existing file instead of a new one, I'm happy to change.

...

### The impact of these changes

1 extra files per locale.

...

### Testing

I made one test, to verify that the exporter creates the structure I expect for a given locale. If there's more testing that would be beneficial, I'm happy to add it.

...

### Checklist

* [ ] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
