### PR TITLE
Add `LanguageInfo` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add `WeekData` component, [#229](https://github.com/ruby-i18n/ruby-cldr/pull/229)
 - Drop support for Ruby 2, [#265](https://github.com/ruby-i18n/ruby-cldr/pull/265)
 - Drop support for Ruby 3.0, [#268](https://github.com/ruby-i18n/ruby-cldr/pull/268)
+- Add `LanguageInfo` component
 
 ---
 

--- a/lib/cldr/export.rb
+++ b/lib/cldr/export.rb
@@ -26,6 +26,7 @@ module Cldr
       :Aliases,
       :CountryCodes,
       :CurrencyDigitsAndRounding,
+      :LanguageInfo,
       :LikelySubtags,
       :Metazones,
       :NumberingSystems,

--- a/lib/cldr/export/data.rb
+++ b/lib/cldr/export/data.rb
@@ -16,6 +16,7 @@ module Cldr
       autoload :Delimiters,                "cldr/export/data/delimiters"
       autoload :Fields,                    "cldr/export/data/fields"
       autoload :Languages,                 "cldr/export/data/languages"
+      autoload :LanguageInfo,              "cldr/export/data/language_info"
       autoload :Layout,                    "cldr/export/data/layout"
       autoload :LikelySubtags,             "cldr/export/data/likely_subtags"
       autoload :Lists,                     "cldr/export/data/lists"

--- a/lib/cldr/export/data/language_info.rb
+++ b/lib/cldr/export/data/language_info.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Cldr
+  module Export
+    module Data
+      class LanguageInfo < Base
+        def initialize
+          super(nil)
+          update(language_matching: language_matching)
+          deep_sort!
+        end
+
+        private
+
+        def language_matching
+          doc.xpath("//languageMatching/languageMatches").each_with_object({}) do |matches_node, ret|
+            matching_type = matches_node.attribute("type").to_s.underscore.to_sym
+            ret[matching_type] = {
+              paradigm_locales: paradigm_locales(matches_node),
+              match_variables: match_variables(matches_node),
+              language_matches: language_matches(matches_node),
+            }
+          end
+        end
+
+        def paradigm_locales(matches_node)
+          locales_node = matches_node.xpath("./paradigmLocales").first
+          return [] unless locales_node
+
+          locales_str = locales_node.attribute("locales").to_s
+          locales_str.split(" ").map { |locale| Cldr::Export.to_i18n(locale).to_s }
+        end
+
+        def match_variables(matches_node)
+          matches_node.xpath("./matchVariable").each_with_object({}) do |var_node, hash|
+            id = var_node.attribute("id").to_s
+            value = var_node.attribute("value").to_s
+            hash[id] = value
+          end
+        end
+
+        def language_matches(matches_node)
+          matches_node.xpath("./languageMatch").map do |match_node|
+            {
+              desired: Cldr::Export.to_i18n(match_node.attribute("desired")).to_s,
+              supported: Cldr::Export.to_i18n(match_node.attribute("supported")).to_s,
+              distance: match_node.attribute("distance").to_s.to_i,
+              oneway: match_node.attribute("oneway").to_s == "true",
+            }.reject { |_, v| v == false }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cldr/export/deep_validate_keys.rb
+++ b/lib/cldr/export/deep_validate_keys.rb
@@ -25,6 +25,10 @@ class DeepValidateKeys
       CountryCodes: [["country_codes", "."]],
       CurrencyDigitsAndRounding: [["."]],
       Fields: [["*", "relative", "."]],
+      LanguageInfo: [
+        ["language_matching", ".", "match_variables", "."],
+        ["language_matching", ".", "paradigm_locales", "."],
+      ],
       Languages: [["languages", "."]],
       LikelySubtags: [["subtags", "."]],
       Metazones: [


### PR DESCRIPTION
### What are you trying to accomplish?

Adding a new component for exporting the info from https://github.com/unicode-org/cldr/blob/main/common/supplemental/languageInfo.xml

Docs: https://www.unicode.org/reports/tr35/tr35-78/tr35.html#LanguageMatching

### What approach did you choose and why?

Basic copy-paste of the other shared components.

### What should reviewers focus on?

🤷 

The data shape matches closely [the upstream](https://github.com/unicode-org/cldr/blob/main/common/supplemental/languageInfo.xml).

The locales are all exported in the hyphenated Ruby i18n way as `String`s (matching `ParentLocales`).

Sample:
```yaml
---
language_matching:
  written_new:
    language_matches:
    - :desired: nb
      :supported: 'no'
      :distance: 1
...
    - :desired: zh-Hant-*
      :supported: zh-Hant-*
      :distance: 5
    - :desired: "*-*-*"
      :supported: "*-*-*"
      :distance: 4
    match_variables:
      "$americas": '019'
      "$cnsar": HK+MO
      "$enUS": AS+CA+GU+MH+MP+PH+PR+UM+US+VI
      "$maghreb": MA+DZ+TN+LY+MR+EH
    paradigm_locales:
    - en
    - en-GB
    - es
    - es-419
    - pt-BR
    - pt-PT
```

Notably, I didn't try to convert `match_variables` into something easier for the consumer to use: they will have to understand how to parse this data still.

### The impact of these changes

Users will be able to get access to these data.

### Testing

```
bundle exec thor cldr:export --components LanguageInfo
```

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
