### PR TITLE
Switch keys to strings in `LanguageInfo` component

### DIFF
--- a/lib/cldr/export/data/language_info.rb
+++ b/lib/cldr/export/data/language_info.rb
@@ -42,10 +42,10 @@ module Cldr
         def language_matches(matches_node)
           matches_node.xpath("./languageMatch").map do |match_node|
             {
-              desired: Cldr::Export.to_i18n(match_node.attribute("desired")).to_s,
-              supported: Cldr::Export.to_i18n(match_node.attribute("supported")).to_s,
-              distance: match_node.attribute("distance").to_s.to_i,
-              oneway: match_node.attribute("oneway").to_s == "true",
+              "desired" => Cldr::Export.to_i18n(match_node.attribute("desired")).to_s,
+              "supported" => Cldr::Export.to_i18n(match_node.attribute("supported")).to_s,
+              "distance" => match_node.attribute("distance").to_s.to_i,
+              "oneway" => match_node.attribute("oneway").to_s == "true",
             }.reject { |_, v| v == false }
           end
         end


### PR DESCRIPTION
### What are you trying to accomplish?

Follow up to #371. Fixing the keys to also be strings. 

### What approach did you choose and why?

Changed the type to String, to match the other components.

### What should reviewers focus on?

🤷 

### The impact of these changes

You won't need to exempt Symbols when trying to safe-load the file.

### Testing

```
bundle exec thor cldr:export --components LanguageInfo
```

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
